### PR TITLE
fix: improve mobile heading wrapping

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -85,8 +85,13 @@ body {
 
 h1,
 h2,
-h3,
-p { overflow-wrap: anywhere; }
+h3 {
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: auto;
+}
+
+p { overflow-wrap: break-word; }
 
 h1 {
   max-width: 980px;
@@ -243,6 +248,10 @@ h3 {
   .section { padding: 48px 0; }
   .section.governance { padding: 32px 24px; }
   .steps li { min-height: auto; }
+  h1 {
+    font-size: clamp(2.35rem, 10.5vw, 4.6rem);
+    letter-spacing: -0.052em;
+  }
 }
 
 @media (max-width: 520px) {
@@ -254,6 +263,10 @@ h3 {
     width: min(100% - 28px, 1120px);
   }
   .section.governance { padding: 28px 20px; }
-  h1 { font-size: clamp(2.35rem, 15vw, 4rem); }
+  h1 {
+    font-size: clamp(2.1rem, 11.2vw, 3.2rem);
+    line-height: 1;
+    letter-spacing: -0.04em;
+  }
   .stage-pill { border-radius: 18px; }
 }


### PR DESCRIPTION
Korrigiert den mobilen Umbruch der Hero-Überschrift.

Enthalten:
- entfernt pauschales overflow-wrap:anywhere von Überschriften
- setzt kontrolliertes Heading-Wrapping
- reduziert H1-Größe und Laufweite auf mobilen Breiten

Keine Änderungen an Inhalt, Formularen, Datenflüssen, Vercel-Konfiguration oder Domain.