### PR TITLE
ZS-WEB-020 – Landingpage v0.3.3 Frank-Vorzeigestand

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Datenschutzerklärung – ZukunftsCheck</title>
+  <link rel="stylesheet" href="src/styles/main.css">
+</head>
+<body>
+  <header class="site-header" aria-label="Kopfbereich">
+    <a class="brand" href="index.html" aria-label="ZukunftsCheck Start">
+      <span class="brand-mark">ZC</span>
+      <span>ZukunftsCheck</span>
+    </a>
+  </header>
+
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-title">
+      <p class="eyebrow">Datenschutz</p>
+      <h1 id="hero-title">Datenschutzerklärung.</h1>
+      <p class="lead">Informationen zur Datenverarbeitung in der internen ZukunftsCheck-Staging-Fassung.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="responsible-title">
+      <div>
+        <p class="section-label">1. Verantwortlicher</p>
+        <h2 id="responsible-title">Verantwortlicher im Sinne der DSGVO</h2>
+      </div>
+      <p>
+        <strong>Media International Bader (M.I.B.) – Hans Leo Bader</strong><br>
+        Heisenbergstr. 2b<br>
+        80937 München<br>
+        E-Mail webmaster(at)muc-mib.de
+      </p>
+    </section>
+
+    <section class="section split" aria-labelledby="contact-title">
+      <div>
+        <p class="section-label">2. Datenschutz-Kontakt</p>
+        <h2 id="contact-title">Kontakt bei Datenschutzfragen</h2>
+      </div>
+      <p>Für Fragen zum Datenschutz wenden Sie sich bitte an webmaster(at)muc-mib.de.</p>
+    </section>
+
+    <section class="section" aria-labelledby="purposes-title">
+      <p class="section-label">3. Zwecke und Rechtsgrundlagen</p>
+      <h2 id="purposes-title">Technische Bereitstellung der Website</h2>
+      <p>Diese Staging-Fassung verarbeitet keine Formularangaben, keine Uploads und keine aktiv eingegebenen personenbezogenen Daten. Beim Aufruf der Website können technisch notwendige Zugriffsdaten verarbeitet werden, insbesondere IP-Adresse, Datum und Uhrzeit des Abrufs, angeforderte Datei, übertragene Datenmenge, Browser- und Betriebssysteminformationen sowie Referrer-URL, soweit dies zur Bereitstellung, Sicherheit und Stabilität der Website erforderlich ist.</p>
+      <p>Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Unser berechtigtes Interesse liegt in der sicheren, stabilen und missbrauchsarmen Bereitstellung der Website.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="hosting-title">
+      <div>
+        <p class="section-label">4. Hosting</p>
+        <h2 id="hosting-title">Hosting und technische Dienstleister</h2>
+      </div>
+      <p>Die technische Bereitstellung kann über externe Hosting- und Infrastruktur-Dienstleister erfolgen. Für die aktuelle interne Staging-Fassung ist insbesondere eine Bereitstellung über GitHub-Repository und Staging-Infrastruktur vorgesehen. Soweit dabei personenbezogene Daten verarbeitet werden, erfolgt dies zur technischen Bereitstellung, Absicherung und Fehlersuche.</p>
+    </section>
+
+    <section class="section" aria-labelledby="no-tracking-title">
+      <p class="section-label">5. Keine Formulare, kein Tracking</p>
+      <h2 id="no-tracking-title">Keine aktive Datenerhebung</h2>
+      <p>Diese Fassung enthält keine Kontaktformulare, keine Upload-Funktion, keine Newsletter-Anmeldung, keine Zahlungsfunktion, keine eingebetteten Karten, keine Video-Embeds, keine Analyse- oder Werbetracking-Dienste und keine automatische Partnervermittlung.</p>
+      <p>Es werden keine personenbezogenen Daten an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="cookies-title">
+      <div>
+        <p class="section-label">6. Cookies und Endgeräte</p>
+        <h2 id="cookies-title">Keine nicht notwendigen Cookies</h2>
+      </div>
+      <p>Nach aktuellem technischen Stand werden in dieser Staging-Fassung keine nicht notwendigen Cookies, keine localStorage-Funktionen und keine vergleichbaren Tracking-Technologien eingesetzt. Sollte sich dies vor einer späteren öffentlichen Nutzung ändern, wird die Datenschutzerklärung entsprechend angepasst und eine gegebenenfalls erforderliche Einwilligungslogik ergänzt.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="duration-title">
+      <div>
+        <p class="section-label">7. Speicherdauer</p>
+        <h2 id="duration-title">Speicherung technischer Zugriffsdaten</h2>
+      </div>
+      <p>Technische Zugriffsdaten werden nur so lange gespeichert, wie dies für Bereitstellung, Sicherheit, Fehleranalyse und Missbrauchserkennung erforderlich ist. Konkrete Speicherfristen hängen vom eingesetzten Hosting-Dienstleister ab und sind vor einer öffentlichen Produktivschaltung final zu prüfen.</p>
+    </section>
+
+    <section class="section" aria-labelledby="rights-title">
+      <p class="section-label">8. Betroffenenrechte</p>
+      <h2 id="rights-title">Ihre Rechte</h2>
+      <p>Sie haben nach der DSGVO insbesondere das Recht auf Auskunft, Berichtigung, Löschung, Einschränkung der Verarbeitung, Datenübertragbarkeit und Widerspruch gegen die Verarbeitung personenbezogener Daten. Außerdem besteht ein Beschwerderecht bei einer Datenschutzaufsichtsbehörde.</p>
+      <p>Wenden Sie sich dazu an webmaster(at)muc-mib.de.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="changes-title">
+      <div>
+        <p class="section-label">9. Änderungen</p>
+        <h2 id="changes-title">Aktualisierung dieser Erklärung</h2>
+      </div>
+      <p>Diese Datenschutzerklärung wird angepasst, wenn sich technische Funktionen, Hosting, Rechtslage oder Verarbeitungsprozesse ändern.</p>
+    </section>
+
+    <section class="status-band" aria-labelledby="status-title">
+      <h2 id="status-title">Aktueller Status</h2>
+      <p>Interne Datenschutz-Staging-Fassung. Keine öffentliche Website-Freigabe. Kein Go-live. Vor öffentlicher Nutzung Hosting, Logdaten, Auftragsverarbeitung und ggf. Cookie-/Einwilligungsfragen final prüfen.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p><a href="index.html">Startseite</a> · <a href="datenschutz.html" aria-current="page">Datenschutz</a> · <a href="impressum.html">Impressum</a></p>
+    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
+  </footer>
+</body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Impressum – ZukunftsCheck</title>
+  <link rel="stylesheet" href="src/styles/main.css">
+</head>
+<body>
+  <header class="site-header" aria-label="Kopfbereich">
+    <a class="brand" href="index.html" aria-label="ZukunftsCheck Start">
+      <span class="brand-mark">ZC</span>
+      <span>ZukunftsCheck</span>
+    </a>
+  </header>
+
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-title">
+      <p class="eyebrow">Rechtliche Angaben</p>
+      <h1 id="hero-title">Impressum.</h1>
+      <p class="lead">Anbieterkennzeichnung für die interne ZukunftsCheck-Staging-Fassung.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="provider-title">
+      <div>
+        <p class="section-label">Diensteanbieter</p>
+        <h2 id="provider-title">Angaben gemäß § 5 DDG / Verantwortlicher gemäß § 18 Abs. 2 MStV</h2>
+      </div>
+      <p>
+        <strong>Media International Bader (M.I.B.) – Hans Leo Bader</strong><br>
+        Heisenbergstr. 2b · 80937 München<br>
+        Telefon +49 (89) 33 04 05 06 · Mobil +49 (177) 76 06 66 0<br>
+        E-Mail webmaster(at)muc-mib.de<br>
+        Vertretungsberechtigt / inhaltlich verantwortlich: Hans Leo Bader
+      </p>
+    </section>
+
+    <section class="section split" aria-labelledby="operation-title">
+      <div>
+        <p class="section-label">Umsetzung</p>
+        <h2 id="operation-title">Technische Infrastruktur und Betrieb</h2>
+      </div>
+      <p>Technische Infrastruktur und Betrieb dieser Staging-Fassung erfolgen durch Media International Bader (M.I.B.). Die Seite ist derzeit nicht öffentlich freigegeben und nicht produktiv geschaltet.</p>
+    </section>
+
+    <section class="section governance" aria-labelledby="liability-title">
+      <p class="section-label">Haftung</p>
+      <h2 id="liability-title">Haftung für Inhalte und externe Links</h2>
+      <p>Als Diensteanbieter sind wir für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Gewähr für die laufende Aktualität, Richtigkeit und Vollständigkeit der bereitgestellten Inhalte.</p>
+      <p>Diese Website kann Links zu externen Websites Dritter enthalten. Auf deren Inhalte haben wir keinen Einfluss; verantwortlich ist jeweils der jeweilige Anbieter oder Betreiber der verlinkten Seiten. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Bei Bekanntwerden konkreter Rechtsverletzungen werden entsprechende Links unverzüglich entfernt.</p>
+    </section>
+
+    <section class="status-band" aria-labelledby="status-title">
+      <h2 id="status-title">Aktueller Status</h2>
+      <p>Interne rechtliche Staging-Fassung. Keine öffentliche Website-Freigabe. Kein Go-live. Vor öffentlicher Nutzung rechtlich und datenschutzseitig final prüfen.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p><a href="index.html">Startseite</a> · <a href="datenschutz.html">Datenschutz</a> · <a href="impressum.html" aria-current="page">Impressum</a></p>
+    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -27,62 +27,52 @@
         <p class="section-label">Zweck</p>
         <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
+      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Infrastruktur, Wasserhaushalt, Flächenpotenziale und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Rollenklärung und der Frage, welche nächsten Schritte sinnvoll sind.</p>
     </section>
 
     <section class="section" aria-labelledby="check-title">
       <p class="section-label">Was wird geprüft?</p>
       <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
-      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind.</p>
+      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Schritte ausreichend klar sind.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
           <h3>Bestand, Nutzung und Bedarf</h3>
-          <p>Gebäude, Nutzungen, Wärmebedarf, Kältebedarf, Sanierungsstand, Verbrauchsdaten, Betriebsweisen und bekannte Planungen werden als Ausgangslage strukturiert.</p>
+          <p>Gebäude, Nutzung, Wärme- und Kältebedarf, Sanierungsstand, bekannte Planungen und offene Fragen werden als Ausgangslage geordnet.</p>
         </article>
         <article class="card">
           <span class="card-number">02</span>
           <h3>Gebäude, Grundstück und Quartier</h3>
-          <p>Flächen, Nachbarschaften, Quartiersbezüge, Infrastrukturbeziehungen und Entwicklungsperspektiven werden ohne technische Vorfestlegung eingeordnet.</p>
+          <p>Grundstück, Quartiersbezug, Nachbarschaft, Infrastruktur und Entwicklungsperspektiven werden ohne technische Vorfestlegung betrachtet.</p>
         </article>
         <article class="card">
           <span class="card-number">03</span>
           <h3>Energie, Wärme, Kälte und Infrastruktur</h3>
-          <p>Versorgungssysteme, Energiebedarf, Schnittstellen zu Planung, Sanierung und Betrieb sowie offene Fachfragen werden technologieoffen sichtbar gemacht.</p>
+          <p>Versorgungssysteme, Energiebedarf und Schnittstellen zu Sanierung, Betrieb und Planung werden technologieoffen sichtbar gemacht.</p>
         </article>
         <article class="card">
           <span class="card-number">04</span>
-          <h3>Risiken, Wasserhaushalt und Standortqualität</h3>
-          <p>Hitzeschutz, Starkregen, Wasserhaushalt, Naturfunktionen, Versicherbarkeit und Gebäudeschutz können als kommunale Infrastruktur- und Risikoperspektive mitgedacht werden.</p>
+          <h3>Risiken und Standortqualität</h3>
+          <p>Hitzeschutz, Starkregen, Wasserhaushalt, Naturfunktionen und Gebäudeschutz können als Standort- und Infrastrukturfragen mitgedacht werden.</p>
         </article>
         <article class="card">
           <span class="card-number">05</span>
           <h3>Entscheidungsrahmen</h3>
-          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar gemacht.</p>
+          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar.</p>
         </article>
       </div>
     </section>
 
     <section class="section process" aria-labelledby="process-title">
       <p class="section-label">Arbeitsweise</p>
-      <h2 id="process-title">Vom Interesse zur strukturierten Klärung.</h2>
+      <h2 id="process-title">Vom Interesse zur Erstklärung.</h2>
       <ol class="steps">
-        <li><span>1</span>Information und Aktivierung</li>
-        <li><span>2</span>Erstfilter und Mindestdaten</li>
-        <li><span>3</span>Koordination von Bestand und Entwicklung</li>
-        <li><span>4</span>Fachliche Vertiefung bei Bedarf</li>
-        <li><span>5</span>Projektentwicklung nach Rollen- und Finanzierungsklärung</li>
-        <li><span>6</span>Umsetzung nach gesonderter Entscheidung</li>
+        <li><span>1</span>Interesse und Ausgangsfrage klären</li>
+        <li><span>2</span>Rolle, Zuständigkeit und Ziel einordnen</li>
+        <li><span>3</span>Gebäude, Bestand oder Quartier grob verorten</li>
+        <li><span>4</span>Offene Fragen und mögliche nächste Schritte sichtbar machen</li>
       </ol>
-      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Analyse, Projektentwicklung und Umsetzung entstehen daraus nicht automatisch, sondern benötigen klare Rollen, belastbare Daten und eine gesonderte Entscheidung.</p>
-    </section>
-
-    <section class="section split" aria-labelledby="coordination-title">
-      <div>
-        <p class="section-label">Koordination</p>
-        <h2 id="coordination-title">Bestand und Entwicklung zusammenführen.</h2>
-      </div>
-      <p>Eine Bestands- und Entwicklungskoordination kann helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung gemeinsam zu betrachten. So werden Schnittstellen sichtbar, bevor einzelne Fachlösungen vertieft werden.</p>
+      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Eine fachliche Vertiefung oder Umsetzung entsteht daraus nicht automatisch. Bei Bedarf können spezialisierte Fachleute erst nach Klärung von Bedarf, Rolle und Freigabe hinzugezogen werden.</p>
     </section>
 
     <section class="section" aria-labelledby="audiences-title">
@@ -91,19 +81,19 @@
       <div class="cards three">
         <article class="card">
           <h3>Kommunen und kommunale Unternehmen</h3>
-          <p>Für Verwaltungen, Stadtwerke, kommunale Gesellschaften und Gremien, die Liegenschaften, Quartiere, Wärmeversorgung, Kühlung, Infrastruktur oder Standortentwicklung systematisch einordnen müssen.</p>
+          <p>Für Verwaltungen, Stadtwerke, kommunale Gesellschaften und Gremien mit Fragen zu Liegenschaften, Quartieren, Wärme, Kühlung, Infrastruktur oder Standortentwicklung.</p>
         </article>
         <article class="card">
           <h3>Wohnungswirtschaft und Bestandshalter</h3>
-          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen, Nutzungsänderungen und langfristigen Investitionsentscheidungen.</p>
+          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen, Nutzungsänderungen und Investitionsentscheidungen.</p>
         </article>
         <article class="card">
           <h3>Gewerbestandorte und öffentliche Gebäude</h3>
-          <p>Für größere Standorte, öffentliche Liegenschaften und Träger, bei denen Wärme, Kälte, Nutzung, Betrieb, Flächen, Infrastruktur und Sanierung zusammen betrachtet werden müssen.</p>
+          <p>Für größere Standorte und öffentliche Liegenschaften, bei denen Wärme, Kälte, Nutzung, Betrieb, Flächen, Infrastruktur und Sanierung zusammenwirken.</p>
         </article>
         <article class="card">
           <h3>Regionale Kooperationen</h3>
-          <p>Für Zusammenschlüsse, Initiativen oder regionale Arbeitszusammenhänge, die mehrere Gebäude, Standorte, Akteure oder Infrastrukturen gemeinsam betrachten wollen.</p>
+          <p>Für Zusammenschlüsse und regionale Arbeitszusammenhänge, die mehrere Gebäude, Standorte, Akteure oder Infrastrukturen gemeinsam betrachten wollen.</p>
         </article>
         <article class="card">
           <h3>Quartiers- und Standortentwicklungen</h3>
@@ -112,34 +102,12 @@
       </div>
     </section>
 
-    <section class="section split" aria-labelledby="partners-title">
-      <div>
-        <p class="section-label">Fachpartnerlogik</p>
-        <h2 id="partners-title">Fachpartner nur nach Bedarf und Freigabe.</h2>
-      </div>
-      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe.</p>
-    </section>
-
-    <section class="section split" aria-labelledby="filter-title">
-      <div>
-        <p class="section-label">Erstfilter</p>
-        <h2 id="filter-title">Mindestdaten statt Schnellversprechen.</h2>
-      </div>
-      <p>Ein Erstfilter kann Organisationsart, Rolle, Objekt oder Quartier, Ausgangslage, Handlungsdruck, vorhandene Daten, Datenlücken, Zeithorizont und Entscheidungsrahmen ordnen. Er schafft eine erste Gesprächs- und Entscheidungsgrundlage, ohne eine Fachplanung zu ersetzen.</p>
-    </section>
-
-    <section class="section governance" aria-labelledby="integrity-title">
-      <p class="section-label">Datenschutz und Integrität</p>
-      <h2 id="integrity-title">Klare Datenwege vor jeder Aktivierung.</h2>
-      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. Daten, Fachprüfung, Medienarbeit und Umsetzung müssen vor einer späteren Aktivierung eindeutig geordnet werden.</p>
-    </section>
-
     <section class="section split" aria-labelledby="start-title">
       <div>
-        <p class="section-label">Ausblick</p>
-        <h2 id="start-title">Wie ein Startprozess aussehen kann.</h2>
+        <p class="section-label">Nächster Schritt</p>
+        <h2 id="start-title">Erstklärung statt Dateneingabe.</h2>
       </div>
-      <p>Ein ZukunftsCheck beginnt mit einer strukturierten Klärung der Ausgangslage: Objekt oder Quartier, Rolle, Datenstand, Handlungsdruck, offene Fragen und Entscheidungsrahmen. Daraus entsteht keine automatische Beauftragung, sondern zunächst eine bessere Grundlage für das weitere Vorgehen.</p>
+      <p>Der ZukunftsCheck beginnt nicht mit einer Dateneingabe, sondern mit einer kurzen Erstklärung. Dabei wird besprochen, worum es geht, wer zuständig ist und welche Informationen später überhaupt benötigt werden. Gebäude-, Verbrauchs-, Mieter-, Eigentümer-, Planungs- oder sonstige Projektdaten werden nicht über die Website erhoben.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">

--- a/index.html
+++ b/index.html
@@ -4,34 +4,84 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
-  <title>ZukunftsCheck – interner Aufbau</title>
+  <title>ZukunftsCheck - Strukturierte Orientierung für zukunftsfähige Räume und Infrastrukturen</title>
   <link rel="stylesheet" href="src/styles/main.css">
 </head>
 <body>
-  <main class="shell" aria-labelledby="page-title">
-    <p class="eyebrow">Interner technischer Aufbau</p>
-    <h1 id="page-title">ZukunftsCheck</h1>
-    <p class="lead">Versionierte Web- und Vorabfragearchitektur für regenerative regionale Infrastrukturentwicklung.</p>
+  <header class="site-header" aria-label="Kopfbereich">
+    <a class="brand" href="#top" aria-label="ZukunftsCheck Start">
+      <span class="brand-mark">ZC</span>
+      <span>ZukunftsCheck</span>
+    </a>
+    <p class="stage-pill">Interner Staging-Stand</p>
+  </header>
 
-    <section class="notice" aria-labelledby="status-title">
-      <h2 id="status-title">Status</h2>
-      <p>Diese Seite ist ein statischer technischer Platzhalter. Es gibt hier keine öffentliche Freigabe, keine Vorabfrage und keine Datenerhebung.</p>
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-title">
+      <p class="eyebrow">Räume · Infrastruktur · Transformation</p>
+      <h1 id="hero-title">Orientierung für tragfähige Zukunftsentscheidungen.</h1>
+      <p class="lead">ZukunftsCheck strukturiert Ausgangslagen, Zielkonflikte, Optionen und nächste Prüfschritte für regionale Infrastruktur- und Transformationsvorhaben.</p>
+      <div class="hero-status" role="note">
+        <strong>Aufbaustatus:</strong> Diese Staging-Seite ist eine interne Design- und Inhaltsfassung. Es werden keine Anfragen entgegengenommen.
+      </div>
     </section>
 
-    <section class="grid" aria-label="Sperrstatus">
-      <article>
-        <h2>Keine Formulare</h2>
-        <p>In dieser Phase sind keine Kontakt- oder Vorabfragefunktionen aktiv.</p>
-      </article>
-      <article>
-        <h2>Keine Echtdaten</h2>
-        <p>Das System verarbeitet keine realen Anfrage-, Personen- oder Organisationsdaten.</p>
-      </article>
-      <article>
-        <h2>Keine Partnerweitergabe</h2>
-        <p>Es findet keine automatische Weiterleitung an Medien-, Fach- oder Technologiepartner statt.</p>
-      </article>
+    <section class="section split" aria-labelledby="context-title">
+      <div>
+        <p class="section-label">Ausgangslage</p>
+        <h2 id="context-title">Vor einzelnen Maßnahmen braucht es Orientierung.</h2>
+      </div>
+      <p>Regionale Zukunftsentscheidungen betreffen Energie, Wärme, Wasser, Fläche, Gebäude, Mobilität, Versorgungssicherheit und ökologische Tragfähigkeit zugleich. ZukunftsCheck schafft zunächst eine nachvollziehbare Grundlage, bevor einzelne Maßnahmen, Technologien oder Planungsschritte bewertet werden.</p>
+    </section>
+
+    <section class="section" aria-labelledby="services-title">
+      <p class="section-label">Leistung</p>
+      <h2 id="services-title">Was ZukunftsCheck leistet</h2>
+      <div class="cards three">
+        <article class="card">
+          <span class="card-number">01</span>
+          <h3>Lage klären</h3>
+          <p>Ausgangslage, Akteure, Ressourcen, Zielkonflikte und offene Fragen sichtbar machen.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">02</span>
+          <h3>Optionen prüfen</h3>
+          <p>Mögliche Entwicklungspfade nach Wirkung, Voraussetzungen, Risiken und Anschlussfähigkeit einordnen.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">03</span>
+          <h3>Nächste Schritte strukturieren</h3>
+          <p>Einen nachvollziehbaren Prüf-, Beteiligungs- und Entscheidungsrahmen für die weitere Bearbeitung vorbereiten.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section process" aria-labelledby="process-title">
+      <p class="section-label">Arbeitslogik</p>
+      <h2 id="process-title">Vom unklaren Vorhaben zum dokumentierten Prüfrahmen.</h2>
+      <ol class="steps">
+        <li><span>1</span>Ausgangslage erfassen</li>
+        <li><span>2</span>Prüffragen und Zielkonflikte klären</li>
+        <li><span>3</span>Optionen und Voraussetzungen einordnen</li>
+        <li><span>4</span>Dokumentierten Prüfrahmen vorbereiten</li>
+      </ol>
+    </section>
+
+    <section class="section governance" aria-labelledby="governance-title">
+      <p class="section-label">Integrität</p>
+      <h2 id="governance-title">Keine automatische Vermittlung.</h2>
+      <p>ZukunftsCheck ist keine automatische Vermittlung und keine verdeckte Weiterleitung. Fachliche Rollen, Datenwege, Interessenkonflikte und Anschlussentscheidungen müssen vor einer späteren Aktivierung gesondert dokumentiert und freigegeben werden.</p>
+    </section>
+
+    <section class="status-band" aria-labelledby="status-title">
+      <h2 id="status-title">Aktueller Status</h2>
+      <p>Die Website befindet sich im kontrollierten Aufbau. Das Vercel-Staging zeigt eine technische und redaktionelle Arbeitsfassung und ist keine öffentliche Website-Freigabe.</p>
     </section>
   </main>
+
+  <footer class="site-footer">
+    <p>ZukunftsCheck · interner Staging-Stand</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · keine Domain-Produktivschaltung</p>
+  </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
       <span class="brand-mark">ZC</span>
       <span>ZukunftsCheck</span>
     </a>
-    <p class="stage-pill">Interner Staging-Stand · keine öffentliche Freigabe</p>
   </header>
 
   <main id="top">
@@ -21,9 +20,6 @@
       <p class="eyebrow">Gebäude · Quartiere · Bestand · kommunale Entwicklung</p>
       <h1 id="hero-title">Orientierung vor der Technikentscheidung.</h1>
       <p class="lead">Der ZukunftsCheck hilft, Gebäude, Grundstücke, Quartiere, Wärme- und Kältefragen sowie kommunale Entwicklungsbedarfe frühzeitig zu ordnen, bevor technische oder investive Festlegungen getroffen werden.</p>
-      <div class="hero-status" role="note">
-        <strong>Aufbaustatus:</strong> Diese Fassung ist eine interne redaktionelle Staging-Fassung. Es gibt keine öffentliche Website-Freigabe, keine Formulare, keine Datenerhebung, kein Tracking, keine Partnerdarstellung und keinen Go-live.
-      </div>
     </section>
 
     <section class="section split" aria-labelledby="purpose-title">
@@ -31,13 +27,13 @@
         <p class="section-label">Zweck</p>
         <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Viele Gebäude, Quartiere und Standorte stehen vor Entscheidungen, bei denen mehrere Ebenen gleichzeitig wirken: Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen, Zuständigkeiten und kommunale Entwicklungsziele. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
+      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
     </section>
 
     <section class="section" aria-labelledby="check-title">
       <p class="section-label">Was wird geprüft?</p>
       <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
-      <p class="section-intro">Geprüft wird nicht, welche Technologie verkauft werden soll, sondern ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind, um später fachlich belastbar weiterzugehen.</p>
+      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
@@ -73,20 +69,20 @@
       <ol class="steps">
         <li><span>1</span>Information und Aktivierung</li>
         <li><span>2</span>Erstfilter und Mindestdaten</li>
-        <li><span>3</span>Planungs-, Bestands- und Entwicklungskoordination</li>
-        <li><span>4</span>Fachliche Vertiefung nur bei Bedarf</li>
-        <li><span>5</span>Projektentwicklung nur nach Auftrag, Rollenklärung und Finanzierung</li>
-        <li><span>6</span>Umsetzung nur nach gesonderter Entscheidung</li>
+        <li><span>3</span>Koordination von Bestand und Entwicklung</li>
+        <li><span>4</span>Fachliche Vertiefung bei Bedarf</li>
+        <li><span>5</span>Projektentwicklung nach Rollen- und Finanzierungsklärung</li>
+        <li><span>6</span>Umsetzung nach gesonderter Entscheidung</li>
       </ol>
-      <p>Analyse, Projektentwicklung und Umsetzung erfolgen nicht automatisch. Sie setzen eine gesonderte Beauftragung, klare Verantwortlichkeiten, transparente Rollen und eine Finanzierungsklärung voraus.</p>
+      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Analyse, Projektentwicklung und Umsetzung entstehen daraus nicht automatisch, sondern benötigen klare Rollen, belastbare Daten und eine gesonderte Entscheidung.</p>
     </section>
 
     <section class="section split" aria-labelledby="coordination-title">
       <div>
         <p class="section-label">Koordination</p>
-        <h2 id="coordination-title">Gebäude, Bestand und Entwicklung zusammenführen.</h2>
+        <h2 id="coordination-title">Bestand und Entwicklung zusammenführen.</h2>
       </div>
-      <p>Bei geeigneten Fällen kann eine Planungs-, Bestands- und Entwicklungskoordination helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung zusammenzuführen, bevor einzelne Fachlösungen vertieft werden. Sie ist keine automatische Projektsteuerung, keine Generalplanung und keine Umsetzungsgarantie.</p>
+      <p>Eine Bestands- und Entwicklungskoordination kann helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung gemeinsam zu betrachten. So werden Schnittstellen sichtbar, bevor einzelne Fachlösungen vertieft werden.</p>
     </section>
 
     <section class="section" aria-labelledby="audiences-title">
@@ -121,7 +117,7 @@
         <p class="section-label">Fachpartnerlogik</p>
         <h2 id="partners-title">Fachpartner nur nach Bedarf und Freigabe.</h2>
       </div>
-      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe. Es erfolgt keine automatische Weiterleitung an Fach-, Technologie-, Medien- oder Umsetzungspartner.</p>
+      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe.</p>
     </section>
 
     <section class="section split" aria-labelledby="filter-title">
@@ -129,13 +125,21 @@
         <p class="section-label">Erstfilter</p>
         <h2 id="filter-title">Mindestdaten statt Schnellversprechen.</h2>
       </div>
-      <p>Ein späterer Erstfilter kann Organisationsart, Rolle, Objekt, Ausgangslage, Handlungsdruck, Datenlage, Zeithorizont und Entscheidungsrahmen ordnen. In dieser internen Staging-Fassung ist der Erstfilter ausschließlich beschrieben. Es gibt keine Eingabefelder, keinen Absenden-Button, keine Uploads, keine Kontaktfelder und keine Datenhaltung.</p>
+      <p>Ein Erstfilter kann Organisationsart, Rolle, Objekt oder Quartier, Ausgangslage, Handlungsdruck, vorhandene Daten, Datenlücken, Zeithorizont und Entscheidungsrahmen ordnen. Er schafft eine erste Gesprächs- und Entscheidungsgrundlage, ohne eine Fachplanung zu ersetzen.</p>
     </section>
 
     <section class="section governance" aria-labelledby="integrity-title">
       <p class="section-label">Datenschutz und Integrität</p>
       <h2 id="integrity-title">Klare Datenwege vor jeder Aktivierung.</h2>
-      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. In dieser internen Staging-Fassung gibt es keine Formulare, keine Kontaktfelder, keine Uploads, keine Datenerhebung, keine sensiblen Daten, keine automatisierte Bewertung, kein Tracking und keine externen Skripte. Rohdaten werden nicht automatisch an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben.</p>
+      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. Daten, Fachprüfung, Medienarbeit und Umsetzung müssen vor einer späteren Aktivierung eindeutig geordnet werden.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="start-title">
+      <div>
+        <p class="section-label">Ausblick</p>
+        <h2 id="start-title">Wie ein Startprozess aussehen kann.</h2>
+      </div>
+      <p>Ein ZukunftsCheck beginnt mit einer strukturierten Klärung der Ausgangslage: Objekt oder Quartier, Rolle, Datenstand, Handlungsdruck, offene Fragen und Entscheidungsrahmen. Daraus entsteht keine automatische Beauftragung, sondern zunächst eine bessere Grundlage für das weitere Vorgehen.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
-  <title>ZukunftsCheck - Gebäude, Quartiere und kommunale Entwicklung</title>
+  <title>ZukunftsCheck - Orientierung vor der Technikentscheidung</title>
   <link rel="stylesheet" href="src/styles/main.css">
 </head>
 <body>
@@ -17,9 +17,9 @@
 
   <main id="top">
     <section class="hero" aria-labelledby="hero-title">
-      <p class="eyebrow">Gebäude · Quartiere · Bestand · kommunale Entwicklung</p>
+      <p class="eyebrow">Leben mit der Energiewende vor Ort</p>
       <h1 id="hero-title">Orientierung vor der Technikentscheidung.</h1>
-      <p class="lead">Der ZukunftsCheck hilft, Gebäude, Grundstücke, Quartiere, Wärme- und Kältefragen sowie kommunale Entwicklungsbedarfe frühzeitig zu ordnen, bevor technische oder investive Festlegungen getroffen werden.</p>
+      <p class="lead">Der ZukunftsCheck hilft Kommunen, Stadtwerken, Bestandshaltern und größeren Standorten, Energie-, Wärme-, Kälte-, Gebäude- und Infrastrukturfragen frühzeitig zu ordnen - ohne Datenupload, ohne Projektversprechen und ohne zweite Fachplanung.</p>
     </section>
 
     <section class="section split" aria-labelledby="purpose-title">
@@ -27,18 +27,18 @@
         <p class="section-label">Zweck</p>
         <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Infrastruktur, Wasserhaushalt, Flächenpotenziale und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Rollenklärung und der Frage, welche nächsten Schritte sinnvoll sind.</p>
+      <p>Der ZukunftsCheck ersetzt keine kommunale Wärmeplanung. Er hilft, vor, neben oder nach bestehenden Fachverfahren Rollen, Zuständigkeiten, Bedarf und nächste Schritte verständlich zu klären.</p>
     </section>
 
     <section class="section" aria-labelledby="check-title">
       <p class="section-label">Was wird geprüft?</p>
       <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
-      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Schritte ausreichend klar sind.</p>
+      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Bedarf, Informationsstand, Zuständigkeiten, Risiken und nächste Schritte ausreichend klar sind.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
-          <h3>Bestand, Nutzung und Bedarf</h3>
-          <p>Gebäude, Nutzung, Wärme- und Kältebedarf, Sanierungsstand, bekannte Planungen und offene Fragen werden als Ausgangslage geordnet.</p>
+          <h3>Bestand, Nutzung und Fragestellung</h3>
+          <p>Gebäude, Nutzung, Wärme- und Kältefragen, Sanierungsstand, bekannte Planungen und offene Punkte werden als Ausgangslage geordnet.</p>
         </article>
         <article class="card">
           <span class="card-number">02</span>
@@ -47,8 +47,8 @@
         </article>
         <article class="card">
           <span class="card-number">03</span>
-          <h3>Energie, Wärme, Kälte und Infrastruktur</h3>
-          <p>Versorgungssysteme, Energiebedarf und Schnittstellen zu Sanierung, Betrieb und Planung werden technologieoffen sichtbar gemacht.</p>
+          <h3>Energie, Wärme, Kälte und Schnittstellen</h3>
+          <p>Versorgungsfragen und Schnittstellen zu Sanierung, Betrieb, Planung und Infrastruktur werden technologieoffen sichtbar gemacht.</p>
         </article>
         <article class="card">
           <span class="card-number">04</span>
@@ -58,26 +58,27 @@
         <article class="card">
           <span class="card-number">05</span>
           <h3>Entscheidungsrahmen</h3>
-          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar.</p>
+          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, offene Punkte und nächste Prüfschritte werden sichtbar.</p>
         </article>
       </div>
     </section>
 
     <section class="section process" aria-labelledby="process-title">
       <p class="section-label">Arbeitsweise</p>
-      <h2 id="process-title">Vom Interesse zur Erstklärung.</h2>
+      <h2 id="process-title">Vom Interesse zur geordneten Erstklärung.</h2>
       <ol class="steps">
-        <li><span>1</span>Interesse und Ausgangsfrage klären</li>
-        <li><span>2</span>Rolle, Zuständigkeit und Ziel einordnen</li>
-        <li><span>3</span>Gebäude, Bestand oder Quartier grob verorten</li>
-        <li><span>4</span>Offene Fragen und mögliche nächste Schritte sichtbar machen</li>
+        <li><span>1</span>Anlass und Ausgangsfrage klären</li>
+        <li><span>2</span>Rolle und Zuständigkeit einordnen</li>
+        <li><span>3</span>Grobes Themenfeld sortieren</li>
+        <li><span>4</span>Sinnvolle nächste Schritte festhalten</li>
       </ol>
-      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Eine fachliche Vertiefung oder Umsetzung entsteht daraus nicht automatisch. Bei Bedarf können spezialisierte Fachleute erst nach Klärung von Bedarf, Rolle und Freigabe hinzugezogen werden.</p>
+      <p>Der Einstieg beginnt mit einer kurzen Erstklärung. Zunächst werden Anlass, Rolle, Zuständigkeit und grobes Themenfeld geklärt. Erst danach wird entschieden, ob und welche fachliche Vertiefung sinnvoll ist.</p>
     </section>
 
     <section class="section" aria-labelledby="audiences-title">
       <p class="section-label">Für wen?</p>
       <h2 id="audiences-title">Für Akteure mit Verantwortung für Gebäude, Quartiere, Infrastruktur und Zukunftsfähigkeit.</h2>
+      <p class="section-intro">Der ZukunftsCheck richtet sich an Kommunen, Stadtwerke, Bestandshalter, öffentliche Träger, Unternehmen, Einrichtungen und größere Standorte, die Energie-, Wärme-, Kälte-, Gebäude- oder Infrastrukturfragen frühzeitig einordnen wollen.</p>
       <div class="cards three">
         <article class="card">
           <h3>Kommunen und kommunale Unternehmen</h3>
@@ -105,20 +106,20 @@
     <section class="section split" aria-labelledby="start-title">
       <div>
         <p class="section-label">Nächster Schritt</p>
-        <h2 id="start-title">Erstklärung statt Dateneingabe.</h2>
+        <h2 id="start-title">Erstklärung statt Datenupload.</h2>
       </div>
-      <p>Der ZukunftsCheck beginnt nicht mit einer Dateneingabe, sondern mit einer kurzen Erstklärung. Dabei wird besprochen, worum es geht, wer zuständig ist und welche Informationen später überhaupt benötigt werden. Gebäude-, Verbrauchs-, Mieter-, Eigentümer-, Planungs- oder sonstige Projektdaten werden nicht über die Website erhoben.</p>
+      <p>Die allgemeine Landingpage erhebt keine Projekt-, Gebäude-, Verbrauchs-, Mieter-, Eigentümer-, Planungs- oder Infrastrukturdaten. Eine Formularintegration bleibt gesondert freigabepflichtig.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Interne redaktionelle Staging-Fassung. Keine öffentliche Website-Freigabe. Keine Formulare. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Kein Go-live.</p>
+      <p>Interne Staging-Fassung. Keine Formulare. Keine Uploads. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Keine Produktivschaltung.</p>
     </section>
   </main>
 
   <footer class="site-footer">
     <p><a href="impressum.html">Impressum</a> · <a href="datenschutz.html">Datenschutz</a></p>
-    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>ZukunftsCheck · interne Staging-Fassung</p>
     <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
   </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
   </main>
 
   <footer class="site-footer">
+    <p><a href="impressum.html">Impressum</a> · <a href="datenschutz.html">Datenschutz</a></p>
     <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
     <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
   </footer>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
-  <title>ZukunftsCheck - Strukturierte Orientierung für zukunftsfähige Räume und Infrastrukturen</title>
+  <title>ZukunftsCheck - Gebäude, Quartiere und kommunale Entwicklung</title>
   <link rel="stylesheet" href="src/styles/main.css">
 </head>
 <body>
@@ -13,75 +13,140 @@
       <span class="brand-mark">ZC</span>
       <span>ZukunftsCheck</span>
     </a>
-    <p class="stage-pill">Interner Staging-Stand</p>
+    <p class="stage-pill">Interner Staging-Stand · keine öffentliche Freigabe</p>
   </header>
 
   <main id="top">
     <section class="hero" aria-labelledby="hero-title">
-      <p class="eyebrow">Räume · Infrastruktur · Transformation</p>
-      <h1 id="hero-title">Orientierung für tragfähige Zukunftsentscheidungen.</h1>
-      <p class="lead">ZukunftsCheck strukturiert Ausgangslagen, Zielkonflikte, Optionen und nächste Prüfschritte für regionale Infrastruktur- und Transformationsvorhaben.</p>
+      <p class="eyebrow">Gebäude · Quartiere · Bestand · kommunale Entwicklung</p>
+      <h1 id="hero-title">Orientierung vor der Technikentscheidung.</h1>
+      <p class="lead">Der ZukunftsCheck hilft, Gebäude, Grundstücke, Quartiere, Wärme- und Kältefragen sowie kommunale Entwicklungsbedarfe frühzeitig zu ordnen, bevor technische oder investive Festlegungen getroffen werden.</p>
       <div class="hero-status" role="note">
-        <strong>Aufbaustatus:</strong> Diese Staging-Seite ist eine interne Design- und Inhaltsfassung. Es werden keine Anfragen entgegengenommen.
+        <strong>Aufbaustatus:</strong> Diese Fassung ist eine interne redaktionelle Staging-Fassung. Es gibt keine öffentliche Website-Freigabe, keine Formulare, keine Datenerhebung, kein Tracking, keine Partnerdarstellung und keinen Go-live.
       </div>
     </section>
 
-    <section class="section split" aria-labelledby="context-title">
+    <section class="section split" aria-labelledby="purpose-title">
       <div>
-        <p class="section-label">Ausgangslage</p>
-        <h2 id="context-title">Vor einzelnen Maßnahmen braucht es Orientierung.</h2>
+        <p class="section-label">Zweck</p>
+        <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Regionale Zukunftsentscheidungen betreffen Energie, Wärme, Wasser, Fläche, Gebäude, Mobilität, Versorgungssicherheit und ökologische Tragfähigkeit zugleich. ZukunftsCheck schafft zunächst eine nachvollziehbare Grundlage, bevor einzelne Maßnahmen, Technologien oder Planungsschritte bewertet werden.</p>
+      <p>Viele Gebäude, Quartiere und Standorte stehen vor Entscheidungen, bei denen mehrere Ebenen gleichzeitig wirken: Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen, Zuständigkeiten und kommunale Entwicklungsziele. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
     </section>
 
-    <section class="section" aria-labelledby="services-title">
-      <p class="section-label">Leistung</p>
-      <h2 id="services-title">Was ZukunftsCheck leistet</h2>
+    <section class="section" aria-labelledby="check-title">
+      <p class="section-label">Was wird geprüft?</p>
+      <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
+      <p class="section-intro">Geprüft wird nicht, welche Technologie verkauft werden soll, sondern ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind, um später fachlich belastbar weiterzugehen.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
-          <h3>Lage klären</h3>
-          <p>Ausgangslage, Akteure, Ressourcen, Zielkonflikte und offene Fragen sichtbar machen.</p>
+          <h3>Bestand, Nutzung und Bedarf</h3>
+          <p>Gebäude, Nutzungen, Wärmebedarf, Kältebedarf, Sanierungsstand, Verbrauchsdaten, Betriebsweisen und bekannte Planungen werden als Ausgangslage strukturiert.</p>
         </article>
         <article class="card">
           <span class="card-number">02</span>
-          <h3>Optionen prüfen</h3>
-          <p>Mögliche Entwicklungspfade nach Wirkung, Voraussetzungen, Risiken und Anschlussfähigkeit einordnen.</p>
+          <h3>Gebäude, Grundstück und Quartier</h3>
+          <p>Flächen, Nachbarschaften, Quartiersbezüge, Infrastrukturbeziehungen und Entwicklungsperspektiven werden ohne technische Vorfestlegung eingeordnet.</p>
         </article>
         <article class="card">
           <span class="card-number">03</span>
-          <h3>Nächste Schritte strukturieren</h3>
-          <p>Einen nachvollziehbaren Prüf-, Beteiligungs- und Entscheidungsrahmen für die weitere Bearbeitung vorbereiten.</p>
+          <h3>Energie, Wärme, Kälte und Infrastruktur</h3>
+          <p>Versorgungssysteme, Energiebedarf, Schnittstellen zu Planung, Sanierung und Betrieb sowie offene Fachfragen werden technologieoffen sichtbar gemacht.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">04</span>
+          <h3>Risiken, Wasserhaushalt und Standortqualität</h3>
+          <p>Hitzeschutz, Starkregen, Wasserhaushalt, Naturfunktionen, Versicherbarkeit und Gebäudeschutz können als kommunale Infrastruktur- und Risikoperspektive mitgedacht werden.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">05</span>
+          <h3>Entscheidungsrahmen</h3>
+          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar gemacht.</p>
         </article>
       </div>
     </section>
 
     <section class="section process" aria-labelledby="process-title">
-      <p class="section-label">Arbeitslogik</p>
-      <h2 id="process-title">Vom unklaren Vorhaben zum dokumentierten Prüfrahmen.</h2>
+      <p class="section-label">Arbeitsweise</p>
+      <h2 id="process-title">Vom Interesse zur strukturierten Klärung.</h2>
       <ol class="steps">
-        <li><span>1</span>Ausgangslage erfassen</li>
-        <li><span>2</span>Prüffragen und Zielkonflikte klären</li>
-        <li><span>3</span>Optionen und Voraussetzungen einordnen</li>
-        <li><span>4</span>Dokumentierten Prüfrahmen vorbereiten</li>
+        <li><span>1</span>Information und Aktivierung</li>
+        <li><span>2</span>Erstfilter und Mindestdaten</li>
+        <li><span>3</span>Planungs-, Bestands- und Entwicklungskoordination</li>
+        <li><span>4</span>Fachliche Vertiefung nur bei Bedarf</li>
+        <li><span>5</span>Projektentwicklung nur nach Auftrag, Rollenklärung und Finanzierung</li>
+        <li><span>6</span>Umsetzung nur nach gesonderter Entscheidung</li>
       </ol>
+      <p>Analyse, Projektentwicklung und Umsetzung erfolgen nicht automatisch. Sie setzen eine gesonderte Beauftragung, klare Verantwortlichkeiten, transparente Rollen und eine Finanzierungsklärung voraus.</p>
     </section>
 
-    <section class="section governance" aria-labelledby="governance-title">
-      <p class="section-label">Integrität</p>
-      <h2 id="governance-title">Keine automatische Vermittlung.</h2>
-      <p>ZukunftsCheck ist keine automatische Vermittlung und keine verdeckte Weiterleitung. Fachliche Rollen, Datenwege, Interessenkonflikte und Anschlussentscheidungen müssen vor einer späteren Aktivierung gesondert dokumentiert und freigegeben werden.</p>
+    <section class="section split" aria-labelledby="coordination-title">
+      <div>
+        <p class="section-label">Koordination</p>
+        <h2 id="coordination-title">Gebäude, Bestand und Entwicklung zusammenführen.</h2>
+      </div>
+      <p>Bei geeigneten Fällen kann eine Planungs-, Bestands- und Entwicklungskoordination helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung zusammenzuführen, bevor einzelne Fachlösungen vertieft werden. Sie ist keine automatische Projektsteuerung, keine Generalplanung und keine Umsetzungsgarantie.</p>
+    </section>
+
+    <section class="section" aria-labelledby="audiences-title">
+      <p class="section-label">Für wen?</p>
+      <h2 id="audiences-title">Für Akteure mit Verantwortung für Gebäude, Quartiere, Infrastruktur und Zukunftsfähigkeit.</h2>
+      <div class="cards three">
+        <article class="card">
+          <h3>Kommunen und kommunale Unternehmen</h3>
+          <p>Für Verwaltungen, Stadtwerke, kommunale Gesellschaften und Gremien, die Liegenschaften, Quartiere, Wärmeversorgung, Kühlung, Infrastruktur oder Standortentwicklung systematisch einordnen müssen.</p>
+        </article>
+        <article class="card">
+          <h3>Wohnungswirtschaft und Bestandshalter</h3>
+          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen, Nutzungsänderungen und langfristigen Investitionsentscheidungen.</p>
+        </article>
+        <article class="card">
+          <h3>Gewerbestandorte und öffentliche Gebäude</h3>
+          <p>Für größere Standorte, öffentliche Liegenschaften und Träger, bei denen Wärme, Kälte, Nutzung, Betrieb, Flächen, Infrastruktur und Sanierung zusammen betrachtet werden müssen.</p>
+        </article>
+        <article class="card">
+          <h3>Regionale Kooperationen</h3>
+          <p>Für Zusammenschlüsse, Initiativen oder regionale Arbeitszusammenhänge, die mehrere Gebäude, Standorte, Akteure oder Infrastrukturen gemeinsam betrachten wollen.</p>
+        </article>
+        <article class="card">
+          <h3>Quartiers- und Standortentwicklungen</h3>
+          <p>Für frühe Entwicklungsfragen, bei denen Gebäude, Grundstück, Nutzung, Energie, Wasserhaushalt, Aufenthaltsqualität und kommunale Ziele zusammenwirken.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section split" aria-labelledby="partners-title">
+      <div>
+        <p class="section-label">Fachpartnerlogik</p>
+        <h2 id="partners-title">Fachpartner nur nach Bedarf und Freigabe.</h2>
+      </div>
+      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe. Es erfolgt keine automatische Weiterleitung an Fach-, Technologie-, Medien- oder Umsetzungspartner.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="filter-title">
+      <div>
+        <p class="section-label">Erstfilter</p>
+        <h2 id="filter-title">Mindestdaten statt Schnellversprechen.</h2>
+      </div>
+      <p>Ein späterer Erstfilter kann Organisationsart, Rolle, Objekt, Ausgangslage, Handlungsdruck, Datenlage, Zeithorizont und Entscheidungsrahmen ordnen. In dieser internen Staging-Fassung ist der Erstfilter ausschließlich beschrieben. Es gibt keine Eingabefelder, keinen Absenden-Button, keine Uploads, keine Kontaktfelder und keine Datenhaltung.</p>
+    </section>
+
+    <section class="section governance" aria-labelledby="integrity-title">
+      <p class="section-label">Datenschutz und Integrität</p>
+      <h2 id="integrity-title">Klare Datenwege vor jeder Aktivierung.</h2>
+      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. In dieser internen Staging-Fassung gibt es keine Formulare, keine Kontaktfelder, keine Uploads, keine Datenerhebung, keine sensiblen Daten, keine automatisierte Bewertung, kein Tracking und keine externen Skripte. Rohdaten werden nicht automatisch an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Die Website befindet sich im kontrollierten Aufbau. Das Vercel-Staging zeigt eine technische und redaktionelle Arbeitsfassung und ist keine öffentliche Website-Freigabe.</p>
+      <p>Interne redaktionelle Staging-Fassung. Keine öffentliche Website-Freigabe. Keine Formulare. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Kein Go-live.</p>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>ZukunftsCheck · interner Staging-Stand</p>
-    <p>Keine Formulare · keine Uploads · keine Datenerhebung · keine Domain-Produktivschaltung</p>
+    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
   </footer>
 </body>
 </html>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Datenschutzerklärung – ZukunftsCheck</title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body>
+  <header class="site-header" aria-label="Kopfbereich">
+    <a class="brand" href="/" aria-label="ZukunftsCheck Start">
+      <span class="brand-mark">ZC</span>
+      <span>ZukunftsCheck</span>
+    </a>
+  </header>
+
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-title">
+      <p class="eyebrow">Datenschutz</p>
+      <h1 id="hero-title">Datenschutzerklärung.</h1>
+      <p class="lead">Informationen zur Datenverarbeitung in der internen ZukunftsCheck-Staging-Fassung.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="responsible-title">
+      <div>
+        <p class="section-label">1. Verantwortlicher</p>
+        <h2 id="responsible-title">Verantwortlicher im Sinne der DSGVO</h2>
+      </div>
+      <p>
+        <strong>Media International Bader (M.I.B.) – Hans Leo Bader</strong><br>
+        Heisenbergstr. 2b<br>
+        80937 München<br>
+        E-Mail webmaster(at)muc-mib.de
+      </p>
+    </section>
+
+    <section class="section split" aria-labelledby="contact-title">
+      <div>
+        <p class="section-label">2. Datenschutz-Kontakt</p>
+        <h2 id="contact-title">Kontakt bei Datenschutzfragen</h2>
+      </div>
+      <p>Für Fragen zum Datenschutz wenden Sie sich bitte an webmaster(at)muc-mib.de.</p>
+    </section>
+
+    <section class="section" aria-labelledby="purposes-title">
+      <p class="section-label">3. Zwecke und Rechtsgrundlagen</p>
+      <h2 id="purposes-title">Technische Bereitstellung der Website</h2>
+      <p>Diese Staging-Fassung verarbeitet keine Formularangaben, keine Uploads und keine aktiv eingegebenen personenbezogenen Daten. Beim Aufruf der Website können technisch notwendige Zugriffsdaten verarbeitet werden, insbesondere IP-Adresse, Datum und Uhrzeit des Abrufs, angeforderte Datei, übertragene Datenmenge, Browser- und Betriebssysteminformationen sowie Referrer-URL, soweit dies zur Bereitstellung, Sicherheit und Stabilität der Website erforderlich ist.</p>
+      <p>Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Unser berechtigtes Interesse liegt in der sicheren, stabilen und missbrauchsarmen Bereitstellung der Website.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="hosting-title">
+      <div>
+        <p class="section-label">4. Hosting</p>
+        <h2 id="hosting-title">Hosting und technische Dienstleister</h2>
+      </div>
+      <p>Die technische Bereitstellung kann über externe Hosting- und Infrastruktur-Dienstleister erfolgen. Für die aktuelle interne Staging-Fassung ist insbesondere eine Bereitstellung über GitHub-Repository und Staging-Infrastruktur vorgesehen. Soweit dabei personenbezogene Daten verarbeitet werden, erfolgt dies zur technischen Bereitstellung, Absicherung und Fehlersuche.</p>
+    </section>
+
+    <section class="section" aria-labelledby="no-tracking-title">
+      <p class="section-label">5. Keine Formulare, kein Tracking</p>
+      <h2 id="no-tracking-title">Keine aktive Datenerhebung</h2>
+      <p>Diese Fassung enthält keine Kontaktformulare, keine Upload-Funktion, keine Newsletter-Anmeldung, keine Zahlungsfunktion, keine eingebetteten Karten, keine Video-Embeds, keine Analyse- oder Werbetracking-Dienste und keine automatische Partnervermittlung.</p>
+      <p>Es werden keine personenbezogenen Daten an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="cookies-title">
+      <div>
+        <p class="section-label">6. Cookies und Endgeräte</p>
+        <h2 id="cookies-title">Keine nicht notwendigen Cookies</h2>
+      </div>
+      <p>Nach aktuellem technischen Stand werden in dieser Staging-Fassung keine nicht notwendigen Cookies, keine localStorage-Funktionen und keine vergleichbaren Tracking-Technologien eingesetzt. Sollte sich dies vor einer späteren öffentlichen Nutzung ändern, wird die Datenschutzerklärung entsprechend angepasst und eine gegebenenfalls erforderliche Einwilligungslogik ergänzt.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="duration-title">
+      <div>
+        <p class="section-label">7. Speicherdauer</p>
+        <h2 id="duration-title">Speicherung technischer Zugriffsdaten</h2>
+      </div>
+      <p>Technische Zugriffsdaten werden nur so lange gespeichert, wie dies für Bereitstellung, Sicherheit, Fehleranalyse und Missbrauchserkennung erforderlich ist. Konkrete Speicherfristen hängen vom eingesetzten Hosting-Dienstleister ab und sind vor einer öffentlichen Produktivschaltung final zu prüfen.</p>
+    </section>
+
+    <section class="section" aria-labelledby="rights-title">
+      <p class="section-label">8. Betroffenenrechte</p>
+      <h2 id="rights-title">Ihre Rechte</h2>
+      <p>Sie haben nach der DSGVO insbesondere das Recht auf Auskunft, Berichtigung, Löschung, Einschränkung der Verarbeitung, Datenübertragbarkeit und Widerspruch gegen die Verarbeitung personenbezogener Daten. Außerdem besteht ein Beschwerderecht bei einer Datenschutzaufsichtsbehörde.</p>
+      <p>Wenden Sie sich dazu an webmaster(at)muc-mib.de.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="changes-title">
+      <div>
+        <p class="section-label">9. Änderungen</p>
+        <h2 id="changes-title">Aktualisierung dieser Erklärung</h2>
+      </div>
+      <p>Diese Datenschutzerklärung wird angepasst, wenn sich technische Funktionen, Hosting, Rechtslage oder Verarbeitungsprozesse ändern.</p>
+    </section>
+
+    <section class="status-band" aria-labelledby="status-title">
+      <h2 id="status-title">Aktueller Status</h2>
+      <p>Interne Datenschutz-Staging-Fassung. Keine öffentliche Website-Freigabe. Kein Go-live. Vor öffentlicher Nutzung Hosting, Logdaten, Auftragsverarbeitung und ggf. Cookie-/Einwilligungsfragen final prüfen.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p><a href="/">Startseite</a> · <a href="/datenschutz.html" aria-current="page">Datenschutz</a> · <a href="/impressum.html">Impressum</a></p>
+    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
+  </footer>
+</body>
+</html>

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Impressum – ZukunftsCheck</title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body>
+  <header class="site-header" aria-label="Kopfbereich">
+    <a class="brand" href="/" aria-label="ZukunftsCheck Start">
+      <span class="brand-mark">ZC</span>
+      <span>ZukunftsCheck</span>
+    </a>
+  </header>
+
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-title">
+      <p class="eyebrow">Rechtliche Angaben</p>
+      <h1 id="hero-title">Impressum.</h1>
+      <p class="lead">Anbieterkennzeichnung für die interne ZukunftsCheck-Staging-Fassung.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="provider-title">
+      <div>
+        <p class="section-label">Diensteanbieter</p>
+        <h2 id="provider-title">Angaben gemäß § 5 DDG / Verantwortlicher gemäß § 18 Abs. 2 MStV</h2>
+      </div>
+      <p>
+        <strong>Media International Bader (M.I.B.) – Hans Leo Bader</strong><br>
+        Heisenbergstr. 2b · 80937 München<br>
+        Telefon +49 (89) 33 04 05 06 · Mobil +49 (177) 76 06 66 0<br>
+        E-Mail webmaster(at)muc-mib.de<br>
+        Vertretungsberechtigt / inhaltlich verantwortlich: Hans Leo Bader
+      </p>
+    </section>
+
+    <section class="section split" aria-labelledby="operation-title">
+      <div>
+        <p class="section-label">Umsetzung</p>
+        <h2 id="operation-title">Technische Infrastruktur und Betrieb</h2>
+      </div>
+      <p>Technische Infrastruktur und Betrieb dieser Staging-Fassung erfolgen durch Media International Bader (M.I.B.). Die Seite ist derzeit nicht öffentlich freigegeben und nicht produktiv geschaltet.</p>
+    </section>
+
+    <section class="section governance" aria-labelledby="liability-title">
+      <p class="section-label">Haftung</p>
+      <h2 id="liability-title">Haftung für Inhalte und externe Links</h2>
+      <p>Als Diensteanbieter sind wir für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Gewähr für die laufende Aktualität, Richtigkeit und Vollständigkeit der bereitgestellten Inhalte.</p>
+      <p>Diese Website kann Links zu externen Websites Dritter enthalten. Auf deren Inhalte haben wir keinen Einfluss; verantwortlich ist jeweils der jeweilige Anbieter oder Betreiber der verlinkten Seiten. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Bei Bekanntwerden konkreter Rechtsverletzungen werden entsprechende Links unverzüglich entfernt.</p>
+    </section>
+
+    <section class="status-band" aria-labelledby="status-title">
+      <h2 id="status-title">Aktueller Status</h2>
+      <p>Interne rechtliche Staging-Fassung. Keine öffentliche Website-Freigabe. Kein Go-live. Vor öffentlicher Nutzung rechtlich und datenschutzseitig final prüfen.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p><a href="/">Startseite</a> · <a href="/datenschutz.html">Datenschutz</a> · <a href="/impressum.html" aria-current="page">Impressum</a></p>
+    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
+  </footer>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -149,6 +149,7 @@
   </main>
 
   <footer class="site-footer">
+    <p><a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a></p>
     <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
     <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
   </footer>

--- a/public/index.html
+++ b/public/index.html
@@ -27,62 +27,52 @@
         <p class="section-label">Zweck</p>
         <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
+      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Infrastruktur, Wasserhaushalt, Flächenpotenziale und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Rollenklärung und der Frage, welche nächsten Schritte sinnvoll sind.</p>
     </section>
 
     <section class="section" aria-labelledby="check-title">
       <p class="section-label">Was wird geprüft?</p>
       <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
-      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind.</p>
+      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Schritte ausreichend klar sind.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
           <h3>Bestand, Nutzung und Bedarf</h3>
-          <p>Gebäude, Nutzungen, Wärmebedarf, Kältebedarf, Sanierungsstand, Verbrauchsdaten, Betriebsweisen und bekannte Planungen werden als Ausgangslage strukturiert.</p>
+          <p>Gebäude, Nutzung, Wärme- und Kältebedarf, Sanierungsstand, bekannte Planungen und offene Fragen werden als Ausgangslage geordnet.</p>
         </article>
         <article class="card">
           <span class="card-number">02</span>
           <h3>Gebäude, Grundstück und Quartier</h3>
-          <p>Flächen, Nachbarschaften, Quartiersbezüge, Infrastrukturbeziehungen und Entwicklungsperspektiven werden ohne technische Vorfestlegung eingeordnet.</p>
+          <p>Grundstück, Quartiersbezug, Nachbarschaft, Infrastruktur und Entwicklungsperspektiven werden ohne technische Vorfestlegung betrachtet.</p>
         </article>
         <article class="card">
           <span class="card-number">03</span>
           <h3>Energie, Wärme, Kälte und Infrastruktur</h3>
-          <p>Versorgungssysteme, Energiebedarf, Schnittstellen zu Planung, Sanierung und Betrieb sowie offene Fachfragen werden technologieoffen sichtbar gemacht.</p>
+          <p>Versorgungssysteme, Energiebedarf und Schnittstellen zu Sanierung, Betrieb und Planung werden technologieoffen sichtbar gemacht.</p>
         </article>
         <article class="card">
           <span class="card-number">04</span>
-          <h3>Risiken, Wasserhaushalt und Standortqualität</h3>
-          <p>Hitzeschutz, Starkregen, Wasserhaushalt, Naturfunktionen, Versicherbarkeit und Gebäudeschutz können als kommunale Infrastruktur- und Risikoperspektive mitgedacht werden.</p>
+          <h3>Risiken und Standortqualität</h3>
+          <p>Hitzeschutz, Starkregen, Wasserhaushalt, Naturfunktionen und Gebäudeschutz können als Standort- und Infrastrukturfragen mitgedacht werden.</p>
         </article>
         <article class="card">
           <span class="card-number">05</span>
           <h3>Entscheidungsrahmen</h3>
-          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar gemacht.</p>
+          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar.</p>
         </article>
       </div>
     </section>
 
     <section class="section process" aria-labelledby="process-title">
       <p class="section-label">Arbeitsweise</p>
-      <h2 id="process-title">Vom Interesse zur strukturierten Klärung.</h2>
+      <h2 id="process-title">Vom Interesse zur Erstklärung.</h2>
       <ol class="steps">
-        <li><span>1</span>Information und Aktivierung</li>
-        <li><span>2</span>Erstfilter und Mindestdaten</li>
-        <li><span>3</span>Koordination von Bestand und Entwicklung</li>
-        <li><span>4</span>Fachliche Vertiefung bei Bedarf</li>
-        <li><span>5</span>Projektentwicklung nach Rollen- und Finanzierungsklärung</li>
-        <li><span>6</span>Umsetzung nach gesonderter Entscheidung</li>
+        <li><span>1</span>Interesse und Ausgangsfrage klären</li>
+        <li><span>2</span>Rolle, Zuständigkeit und Ziel einordnen</li>
+        <li><span>3</span>Gebäude, Bestand oder Quartier grob verorten</li>
+        <li><span>4</span>Offene Fragen und mögliche nächste Schritte sichtbar machen</li>
       </ol>
-      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Analyse, Projektentwicklung und Umsetzung entstehen daraus nicht automatisch, sondern benötigen klare Rollen, belastbare Daten und eine gesonderte Entscheidung.</p>
-    </section>
-
-    <section class="section split" aria-labelledby="coordination-title">
-      <div>
-        <p class="section-label">Koordination</p>
-        <h2 id="coordination-title">Bestand und Entwicklung zusammenführen.</h2>
-      </div>
-      <p>Eine Bestands- und Entwicklungskoordination kann helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung gemeinsam zu betrachten. So werden Schnittstellen sichtbar, bevor einzelne Fachlösungen vertieft werden.</p>
+      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Eine fachliche Vertiefung oder Umsetzung entsteht daraus nicht automatisch. Bei Bedarf können spezialisierte Fachleute erst nach Klärung von Bedarf, Rolle und Freigabe hinzugezogen werden.</p>
     </section>
 
     <section class="section" aria-labelledby="audiences-title">
@@ -91,19 +81,19 @@
       <div class="cards three">
         <article class="card">
           <h3>Kommunen und kommunale Unternehmen</h3>
-          <p>Für Verwaltungen, Stadtwerke, kommunale Gesellschaften und Gremien, die Liegenschaften, Quartiere, Wärmeversorgung, Kühlung, Infrastruktur oder Standortentwicklung systematisch einordnen müssen.</p>
+          <p>Für Verwaltungen, Stadtwerke, kommunale Gesellschaften und Gremien mit Fragen zu Liegenschaften, Quartieren, Wärme, Kühlung, Infrastruktur oder Standortentwicklung.</p>
         </article>
         <article class="card">
           <h3>Wohnungswirtschaft und Bestandshalter</h3>
-          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen, Nutzungsänderungen und langfristigen Investitionsentscheidungen.</p>
+          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen, Nutzungsänderungen und Investitionsentscheidungen.</p>
         </article>
         <article class="card">
           <h3>Gewerbestandorte und öffentliche Gebäude</h3>
-          <p>Für größere Standorte, öffentliche Liegenschaften und Träger, bei denen Wärme, Kälte, Nutzung, Betrieb, Flächen, Infrastruktur und Sanierung zusammen betrachtet werden müssen.</p>
+          <p>Für größere Standorte und öffentliche Liegenschaften, bei denen Wärme, Kälte, Nutzung, Betrieb, Flächen, Infrastruktur und Sanierung zusammenwirken.</p>
         </article>
         <article class="card">
           <h3>Regionale Kooperationen</h3>
-          <p>Für Zusammenschlüsse, Initiativen oder regionale Arbeitszusammenhänge, die mehrere Gebäude, Standorte, Akteure oder Infrastrukturen gemeinsam betrachten wollen.</p>
+          <p>Für Zusammenschlüsse und regionale Arbeitszusammenhänge, die mehrere Gebäude, Standorte, Akteure oder Infrastrukturen gemeinsam betrachten wollen.</p>
         </article>
         <article class="card">
           <h3>Quartiers- und Standortentwicklungen</h3>
@@ -112,34 +102,12 @@
       </div>
     </section>
 
-    <section class="section split" aria-labelledby="partners-title">
-      <div>
-        <p class="section-label">Fachpartnerlogik</p>
-        <h2 id="partners-title">Fachpartner nur nach Bedarf und Freigabe.</h2>
-      </div>
-      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe.</p>
-    </section>
-
-    <section class="section split" aria-labelledby="filter-title">
-      <div>
-        <p class="section-label">Erstfilter</p>
-        <h2 id="filter-title">Mindestdaten statt Schnellversprechen.</h2>
-      </div>
-      <p>Ein Erstfilter kann Organisationsart, Rolle, Objekt oder Quartier, Ausgangslage, Handlungsdruck, vorhandene Daten, Datenlücken, Zeithorizont und Entscheidungsrahmen ordnen. Er schafft eine erste Gesprächs- und Entscheidungsgrundlage, ohne eine Fachplanung zu ersetzen.</p>
-    </section>
-
-    <section class="section governance" aria-labelledby="integrity-title">
-      <p class="section-label">Datenschutz und Integrität</p>
-      <h2 id="integrity-title">Klare Datenwege vor jeder Aktivierung.</h2>
-      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. Daten, Fachprüfung, Medienarbeit und Umsetzung müssen vor einer späteren Aktivierung eindeutig geordnet werden.</p>
-    </section>
-
     <section class="section split" aria-labelledby="start-title">
       <div>
-        <p class="section-label">Ausblick</p>
-        <h2 id="start-title">Wie ein Startprozess aussehen kann.</h2>
+        <p class="section-label">Nächster Schritt</p>
+        <h2 id="start-title">Erstklärung statt Dateneingabe.</h2>
       </div>
-      <p>Ein ZukunftsCheck beginnt mit einer strukturierten Klärung der Ausgangslage: Objekt oder Quartier, Rolle, Datenstand, Handlungsdruck, offene Fragen und Entscheidungsrahmen. Daraus entsteht keine automatische Beauftragung, sondern zunächst eine bessere Grundlage für das weitere Vorgehen.</p>
+      <p>Der ZukunftsCheck beginnt nicht mit einer Dateneingabe, sondern mit einer kurzen Erstklärung. Dabei wird besprochen, worum es geht, wer zuständig ist und welche Informationen später überhaupt benötigt werden. Gebäude-, Verbrauchs-, Mieter-, Eigentümer-, Planungs- oder sonstige Projektdaten werden nicht über die Website erhoben.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,6 @@
       <span class="brand-mark">ZC</span>
       <span>ZukunftsCheck</span>
     </a>
-    <p class="stage-pill">Interner Staging-Stand · keine öffentliche Freigabe</p>
   </header>
 
   <main id="top">
@@ -21,9 +20,6 @@
       <p class="eyebrow">Gebäude · Quartiere · Bestand · kommunale Entwicklung</p>
       <h1 id="hero-title">Orientierung vor der Technikentscheidung.</h1>
       <p class="lead">Der ZukunftsCheck hilft, Gebäude, Grundstücke, Quartiere, Wärme- und Kältefragen sowie kommunale Entwicklungsbedarfe frühzeitig zu ordnen, bevor technische oder investive Festlegungen getroffen werden.</p>
-      <div class="hero-status" role="note">
-        <strong>Aufbaustatus:</strong> Diese Fassung ist eine interne redaktionelle Staging-Fassung. Es gibt keine öffentliche Website-Freigabe, keine Formulare, keine Datenerhebung, kein Tracking, keine Partnerdarstellung und keinen Go-live.
-      </div>
     </section>
 
     <section class="section split" aria-labelledby="purpose-title">
@@ -31,13 +27,13 @@
         <p class="section-label">Zweck</p>
         <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Viele Gebäude, Quartiere und Standorte stehen vor Entscheidungen, bei denen mehrere Ebenen gleichzeitig wirken: Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen, Zuständigkeiten und kommunale Entwicklungsziele. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
+      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
     </section>
 
     <section class="section" aria-labelledby="check-title">
       <p class="section-label">Was wird geprüft?</p>
       <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
-      <p class="section-intro">Geprüft wird nicht, welche Technologie verkauft werden soll, sondern ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind, um später fachlich belastbar weiterzugehen.</p>
+      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
@@ -73,20 +69,20 @@
       <ol class="steps">
         <li><span>1</span>Information und Aktivierung</li>
         <li><span>2</span>Erstfilter und Mindestdaten</li>
-        <li><span>3</span>Planungs-, Bestands- und Entwicklungskoordination</li>
-        <li><span>4</span>Fachliche Vertiefung nur bei Bedarf</li>
-        <li><span>5</span>Projektentwicklung nur nach Auftrag, Rollenklärung und Finanzierung</li>
-        <li><span>6</span>Umsetzung nur nach gesonderter Entscheidung</li>
+        <li><span>3</span>Koordination von Bestand und Entwicklung</li>
+        <li><span>4</span>Fachliche Vertiefung bei Bedarf</li>
+        <li><span>5</span>Projektentwicklung nach Rollen- und Finanzierungsklärung</li>
+        <li><span>6</span>Umsetzung nach gesonderter Entscheidung</li>
       </ol>
-      <p>Analyse, Projektentwicklung und Umsetzung erfolgen nicht automatisch. Sie setzen eine gesonderte Beauftragung, klare Verantwortlichkeiten, transparente Rollen und eine Finanzierungsklärung voraus.</p>
+      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Analyse, Projektentwicklung und Umsetzung entstehen daraus nicht automatisch, sondern benötigen klare Rollen, belastbare Daten und eine gesonderte Entscheidung.</p>
     </section>
 
     <section class="section split" aria-labelledby="coordination-title">
       <div>
         <p class="section-label">Koordination</p>
-        <h2 id="coordination-title">Gebäude, Bestand und Entwicklung zusammenführen.</h2>
+        <h2 id="coordination-title">Bestand und Entwicklung zusammenführen.</h2>
       </div>
-      <p>Bei geeigneten Fällen kann eine Planungs-, Bestands- und Entwicklungskoordination helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung zusammenzuführen, bevor einzelne Fachlösungen vertieft werden. Sie ist keine automatische Projektsteuerung, keine Generalplanung und keine Umsetzungsgarantie.</p>
+      <p>Eine Bestands- und Entwicklungskoordination kann helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung gemeinsam zu betrachten. So werden Schnittstellen sichtbar, bevor einzelne Fachlösungen vertieft werden.</p>
     </section>
 
     <section class="section" aria-labelledby="audiences-title">
@@ -121,7 +117,7 @@
         <p class="section-label">Fachpartnerlogik</p>
         <h2 id="partners-title">Fachpartner nur nach Bedarf und Freigabe.</h2>
       </div>
-      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe. Es erfolgt keine automatische Weiterleitung an Fach-, Technologie-, Medien- oder Umsetzungspartner.</p>
+      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe.</p>
     </section>
 
     <section class="section split" aria-labelledby="filter-title">
@@ -129,13 +125,21 @@
         <p class="section-label">Erstfilter</p>
         <h2 id="filter-title">Mindestdaten statt Schnellversprechen.</h2>
       </div>
-      <p>Ein späterer Erstfilter kann Organisationsart, Rolle, Objekt, Ausgangslage, Handlungsdruck, Datenlage, Zeithorizont und Entscheidungsrahmen ordnen. In dieser internen Staging-Fassung ist der Erstfilter ausschließlich beschrieben. Es gibt keine Eingabefelder, keinen Absenden-Button, keine Uploads, keine Kontaktfelder und keine Datenhaltung.</p>
+      <p>Ein Erstfilter kann Organisationsart, Rolle, Objekt oder Quartier, Ausgangslage, Handlungsdruck, vorhandene Daten, Datenlücken, Zeithorizont und Entscheidungsrahmen ordnen. Er schafft eine erste Gesprächs- und Entscheidungsgrundlage, ohne eine Fachplanung zu ersetzen.</p>
     </section>
 
     <section class="section governance" aria-labelledby="integrity-title">
       <p class="section-label">Datenschutz und Integrität</p>
       <h2 id="integrity-title">Klare Datenwege vor jeder Aktivierung.</h2>
-      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. In dieser internen Staging-Fassung gibt es keine Formulare, keine Kontaktfelder, keine Uploads, keine Datenerhebung, keine sensiblen Daten, keine automatisierte Bewertung, kein Tracking und keine externen Skripte. Rohdaten werden nicht automatisch an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben.</p>
+      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. Daten, Fachprüfung, Medienarbeit und Umsetzung müssen vor einer späteren Aktivierung eindeutig geordnet werden.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="start-title">
+      <div>
+        <p class="section-label">Ausblick</p>
+        <h2 id="start-title">Wie ein Startprozess aussehen kann.</h2>
+      </div>
+      <p>Ein ZukunftsCheck beginnt mit einer strukturierten Klärung der Ausgangslage: Objekt oder Quartier, Rolle, Datenstand, Handlungsdruck, offene Fragen und Entscheidungsrahmen. Daraus entsteht keine automatische Beauftragung, sondern zunächst eine bessere Grundlage für das weitere Vorgehen.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
-  <title>ZukunftsCheck - Strukturierte Orientierung für zukunftsfähige Räume und Infrastrukturen</title>
+  <title>ZukunftsCheck – Wärme, Kälte, Gebäude und Quartiere</title>
   <link rel="stylesheet" href="/styles/main.css">
 </head>
 <body>
@@ -13,75 +13,104 @@
       <span class="brand-mark">ZC</span>
       <span>ZukunftsCheck</span>
     </a>
-    <p class="stage-pill">Interner Staging-Stand</p>
+    <p class="stage-pill">Interner Staging-Stand · keine öffentliche Freigabe</p>
   </header>
 
   <main id="top">
     <section class="hero" aria-labelledby="hero-title">
-      <p class="eyebrow">Räume · Infrastruktur · Transformation</p>
-      <h1 id="hero-title">Orientierung für tragfähige Zukunftsentscheidungen.</h1>
-      <p class="lead">ZukunftsCheck strukturiert Ausgangslagen, Zielkonflikte, Optionen und nächste Prüfschritte für regionale Infrastruktur- und Transformationsvorhaben.</p>
+      <p class="eyebrow">Wärme · Kälte · Gebäude · Quartiere</p>
+      <h1 id="hero-title">Orientierung vor der Technikentscheidung.</h1>
+      <p class="lead">Der ZukunftsCheck strukturiert Ausgangslage, Datenstand, Handlungsdruck, Zielkonflikte und nächste Prüfschritte, bevor technische oder investive Festlegungen getroffen werden.</p>
       <div class="hero-status" role="note">
-        <strong>Aufbaustatus:</strong> Diese Staging-Seite ist eine interne Design- und Inhaltsfassung. Es werden keine Anfragen entgegengenommen.
+        <strong>Aufbaustatus:</strong> Diese Fassung ist eine interne statische Staging-Arbeitsfassung. Es gibt kein Formular, keine Datenerhebung, kein Tracking und keine automatische Partnervermittlung.
       </div>
     </section>
 
-    <section class="section split" aria-labelledby="context-title">
+    <section class="section split" aria-labelledby="purpose-title">
       <div>
-        <p class="section-label">Ausgangslage</p>
-        <h2 id="context-title">Vor einzelnen Maßnahmen braucht es Orientierung.</h2>
+        <p class="section-label">Zweck</p>
+        <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Regionale Zukunftsentscheidungen betreffen Energie, Wärme, Wasser, Fläche, Gebäude, Mobilität, Versorgungssicherheit und ökologische Tragfähigkeit zugleich. ZukunftsCheck schafft zunächst eine nachvollziehbare Grundlage, bevor einzelne Maßnahmen, Technologien oder Planungsschritte bewertet werden.</p>
+      <p>Viele Gebäude, Quartiere und Standorte stehen vor komplexen Entscheidungen: Wärmeversorgung, Kühlung, Sanierung, Energiebedarf, Flächenpotenziale, Investitionszyklen und organisatorische Zuständigkeiten greifen ineinander. Häufig beginnt die Debatte zu früh bei einzelnen technischen Lösungen. Der ZukunftsCheck setzt früher an: bei Orientierung, Mindestdaten, Entscheidungsrahmen und Prüffähigkeit.</p>
     </section>
 
-    <section class="section" aria-labelledby="services-title">
-      <p class="section-label">Leistung</p>
-      <h2 id="services-title">Was ZukunftsCheck leistet</h2>
+    <section class="section" aria-labelledby="check-title">
+      <p class="section-label">Was wird geprüft?</p>
+      <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
-          <h3>Lage klären</h3>
-          <p>Ausgangslage, Akteure, Ressourcen, Zielkonflikte und offene Fragen sichtbar machen.</p>
+          <h3>Bestand und Bedarf</h3>
+          <p>Gebäude, Nutzungen, Wärmebedarf, Kältebedarf, Sanierungsstand, Verbrauchsdaten und bekannte Planungen werden als Ausgangslage strukturiert.</p>
         </article>
         <article class="card">
           <span class="card-number">02</span>
-          <h3>Optionen prüfen</h3>
-          <p>Mögliche Entwicklungspfade nach Wirkung, Voraussetzungen, Risiken und Anschlussfähigkeit einordnen.</p>
+          <h3>Quartier und Umfeld</h3>
+          <p>Flächen, Quellenpotenziale, Nachbarschaften, Netze, Infrastrukturbeziehungen und Entwicklungsperspektiven werden ohne technische Vorfestlegung eingeordnet.</p>
         </article>
         <article class="card">
           <span class="card-number">03</span>
-          <h3>Nächste Schritte strukturieren</h3>
-          <p>Einen nachvollziehbaren Prüf-, Beteiligungs- und Entscheidungsrahmen für die weitere Bearbeitung vorbereiten.</p>
+          <h3>Entscheidungsrahmen</h3>
+          <p>Zuständigkeiten, Mandat, Handlungsdruck, Zeithorizont, Datenlücken und nächste Prüfschritte werden sichtbar gemacht.</p>
         </article>
       </div>
     </section>
 
     <section class="section process" aria-labelledby="process-title">
-      <p class="section-label">Arbeitslogik</p>
-      <h2 id="process-title">Vom unklaren Vorhaben zum dokumentierten Prüfrahmen.</h2>
+      <p class="section-label">Arbeitsweise</p>
+      <h2 id="process-title">Vom Interesse zur strukturierten Klärung.</h2>
       <ol class="steps">
-        <li><span>1</span>Ausgangslage erfassen</li>
-        <li><span>2</span>Prüffragen und Zielkonflikte klären</li>
-        <li><span>3</span>Optionen und Voraussetzungen einordnen</li>
-        <li><span>4</span>Dokumentierten Prüfrahmen vorbereiten</li>
+        <li><span>1</span>Information und Aktivierung</li>
+        <li><span>2</span>Erstfilter und Mindestdaten</li>
+        <li><span>3</span>ZukunftsCheck als Vorprüfung</li>
+        <li><span>4</span>Analyse nur nach Auftrag</li>
+        <li><span>5</span>Projektentwicklung nur nach Rollen- und Finanzierungsklärung</li>
       </ol>
+      <p>Analyse, Projektentwicklung und Umsetzung erfolgen nicht automatisch. Sie setzen eine gesonderte Beauftragung, klare Verantwortlichkeiten und transparente Rollen voraus.</p>
     </section>
 
-    <section class="section governance" aria-labelledby="governance-title">
-      <p class="section-label">Integrität</p>
-      <h2 id="governance-title">Keine automatische Vermittlung.</h2>
-      <p>ZukunftsCheck ist keine automatische Vermittlung und keine verdeckte Weiterleitung. Fachliche Rollen, Datenwege, Interessenkonflikte und Anschlussentscheidungen müssen vor einer späteren Aktivierung gesondert dokumentiert und freigegeben werden.</p>
+    <section class="section" aria-labelledby="audiences-title">
+      <p class="section-label">Für wen?</p>
+      <h2 id="audiences-title">Für Akteure mit Verantwortung für Wärme, Kälte, Gebäude und Quartiere.</h2>
+      <div class="cards three">
+        <article class="card">
+          <h3>Kommunen und kommunale Unternehmen</h3>
+          <p>Für Verwaltungen, Stadtwerke und Gremien, die Liegenschaften, Quartiere, Wärmeversorgung oder Infrastruktur systematisch einordnen müssen.</p>
+        </article>
+        <article class="card">
+          <h3>Wohnungswirtschaft und Bestandshalter</h3>
+          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen und langfristigen Investitionsentscheidungen.</p>
+        </article>
+        <article class="card">
+          <h3>Gewerbe und regionale Kooperationen</h3>
+          <p>Für größere Standorte und Zusammenschlüsse, die Wärme-, Kälte-, Energie- oder Infrastrukturfragen im Zusammenhang betrachten müssen.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section split" aria-labelledby="filter-title">
+      <div>
+        <p class="section-label">Erstfilter</p>
+        <h2 id="filter-title">Mindestdaten statt Schnellversprechen.</h2>
+      </div>
+      <p>Ein späterer Erstfilter kann Organisationsart, Rolle, Objekt, Ausgangslage, Handlungsdruck, Datenlage, Zeithorizont und Entscheidungsrahmen ordnen. In dieser Staging-Fassung ist der Erstfilter ausschließlich beschreibend. Es gibt keine Eingabefelder, keinen Absenden-Button, keine Uploads und keine Datenhaltung.</p>
+    </section>
+
+    <section class="section governance" aria-labelledby="integrity-title">
+      <p class="section-label">Datenschutz und Integrität</p>
+      <h2 id="integrity-title">Klare Datenwege vor jeder Aktivierung.</h2>
+      <p>ZukunftsCheck arbeitet nur glaubwürdig, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. Eine Anfrage würde nicht automatisch an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben. Rohdaten, sensible Daten, Uploads, Tracking und automatisierte Bewertungen sind in dieser Fassung ausgeschlossen.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Die Website befindet sich im kontrollierten Aufbau. Das Vercel-Staging zeigt eine technische und redaktionelle Arbeitsfassung und ist keine öffentliche Website-Freigabe.</p>
+      <p>Interne statische Staging-Fassung auf isolierter Arbeitslinie. Keine öffentliche Website-Freigabe. Keine Formulare. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Kein Go-live.</p>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>ZukunftsCheck · interner Staging-Stand</p>
-    <p>Keine Formulare · keine Uploads · keine Datenerhebung · keine Domain-Produktivschaltung</p>
+    <p>ZukunftsCheck · interne statische Staging-Fassung</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Produktivschaltung</p>
   </footer>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
-  <title>ZukunftsCheck – Wärme, Kälte, Gebäude und Quartiere</title>
+  <title>ZukunftsCheck – Gebäude, Quartiere und kommunale Entwicklung</title>
   <link rel="stylesheet" href="/styles/main.css">
 </head>
 <body>
@@ -18,11 +18,11 @@
 
   <main id="top">
     <section class="hero" aria-labelledby="hero-title">
-      <p class="eyebrow">Wärme · Kälte · Gebäude · Quartiere</p>
+      <p class="eyebrow">Gebäude · Quartiere · Bestand · kommunale Entwicklung</p>
       <h1 id="hero-title">Orientierung vor der Technikentscheidung.</h1>
-      <p class="lead">Der ZukunftsCheck strukturiert Ausgangslage, Datenstand, Handlungsdruck, Zielkonflikte und nächste Prüfschritte, bevor technische oder investive Festlegungen getroffen werden.</p>
+      <p class="lead">Der ZukunftsCheck hilft, Gebäude, Grundstücke, Quartiere, Wärme- und Kältefragen sowie kommunale Entwicklungsbedarfe frühzeitig zu ordnen, bevor technische oder investive Festlegungen getroffen werden.</p>
       <div class="hero-status" role="note">
-        <strong>Aufbaustatus:</strong> Diese Fassung ist eine interne statische Staging-Arbeitsfassung. Es gibt kein Formular, keine Datenerhebung, kein Tracking und keine automatische Partnervermittlung.
+        <strong>Aufbaustatus:</strong> Diese Fassung ist eine interne redaktionelle Staging-Fassung. Es gibt keine öffentliche Website-Freigabe, keine Formulare, keine Datenerhebung, kein Tracking, keine Partnerdarstellung und keinen Go-live.
       </div>
     </section>
 
@@ -31,27 +31,38 @@
         <p class="section-label">Zweck</p>
         <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Viele Gebäude, Quartiere und Standorte stehen vor komplexen Entscheidungen: Wärmeversorgung, Kühlung, Sanierung, Energiebedarf, Flächenpotenziale, Investitionszyklen und organisatorische Zuständigkeiten greifen ineinander. Häufig beginnt die Debatte zu früh bei einzelnen technischen Lösungen. Der ZukunftsCheck setzt früher an: bei Orientierung, Mindestdaten, Entscheidungsrahmen und Prüffähigkeit.</p>
+      <p>Viele Gebäude, Quartiere und Standorte stehen vor Entscheidungen, bei denen mehrere Ebenen gleichzeitig wirken: Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Energieinfrastruktur, Wasserhaushalt, Flächenpotenziale, Investitionszyklen, Zuständigkeiten und kommunale Entwicklungsziele. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Mindestdaten, Rollenklärung, Entscheidungsrahmen und Prüffähigkeit.</p>
     </section>
 
     <section class="section" aria-labelledby="check-title">
       <p class="section-label">Was wird geprüft?</p>
       <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
+      <p class="section-intro">Geprüft wird nicht, welche Technologie verkauft werden soll, sondern ob Ausgangslage, Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Prüfschritte ausreichend klar sind, um später fachlich belastbar weiterzugehen.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
-          <h3>Bestand und Bedarf</h3>
-          <p>Gebäude, Nutzungen, Wärmebedarf, Kältebedarf, Sanierungsstand, Verbrauchsdaten und bekannte Planungen werden als Ausgangslage strukturiert.</p>
+          <h3>Bestand, Nutzung und Bedarf</h3>
+          <p>Gebäude, Nutzungen, Wärmebedarf, Kältebedarf, Sanierungsstand, Verbrauchsdaten, Betriebsweisen und bekannte Planungen werden als Ausgangslage strukturiert.</p>
         </article>
         <article class="card">
           <span class="card-number">02</span>
-          <h3>Quartier und Umfeld</h3>
-          <p>Flächen, Quellenpotenziale, Nachbarschaften, Netze, Infrastrukturbeziehungen und Entwicklungsperspektiven werden ohne technische Vorfestlegung eingeordnet.</p>
+          <h3>Gebäude, Grundstück und Quartier</h3>
+          <p>Flächen, Nachbarschaften, Quartiersbezüge, Infrastrukturbeziehungen und Entwicklungsperspektiven werden ohne technische Vorfestlegung eingeordnet.</p>
         </article>
         <article class="card">
           <span class="card-number">03</span>
+          <h3>Energie, Wärme, Kälte und Infrastruktur</h3>
+          <p>Versorgungssysteme, Energiebedarf, Schnittstellen zu Planung, Sanierung und Betrieb sowie offene Fachfragen werden technologieoffen sichtbar gemacht.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">04</span>
+          <h3>Risiken, Wasserhaushalt und Standortqualität</h3>
+          <p>Hitzeschutz, Starkregen, Wasserhaushalt, Naturfunktionen, Versicherbarkeit und Gebäudeschutz können als kommunale Infrastruktur- und Risikoperspektive mitgedacht werden.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">05</span>
           <h3>Entscheidungsrahmen</h3>
-          <p>Zuständigkeiten, Mandat, Handlungsdruck, Zeithorizont, Datenlücken und nächste Prüfschritte werden sichtbar gemacht.</p>
+          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar gemacht.</p>
         </article>
       </div>
     </section>
@@ -62,30 +73,55 @@
       <ol class="steps">
         <li><span>1</span>Information und Aktivierung</li>
         <li><span>2</span>Erstfilter und Mindestdaten</li>
-        <li><span>3</span>ZukunftsCheck als Vorprüfung</li>
-        <li><span>4</span>Analyse nur nach Auftrag</li>
-        <li><span>5</span>Projektentwicklung nur nach Rollen- und Finanzierungsklärung</li>
+        <li><span>3</span>Planungs-, Bestands- und Entwicklungskoordination</li>
+        <li><span>4</span>Fachliche Vertiefung nur bei Bedarf</li>
+        <li><span>5</span>Projektentwicklung nur nach Auftrag, Rollenklärung und Finanzierung</li>
+        <li><span>6</span>Umsetzung nur nach gesonderter Entscheidung</li>
       </ol>
-      <p>Analyse, Projektentwicklung und Umsetzung erfolgen nicht automatisch. Sie setzen eine gesonderte Beauftragung, klare Verantwortlichkeiten und transparente Rollen voraus.</p>
+      <p>Analyse, Projektentwicklung und Umsetzung erfolgen nicht automatisch. Sie setzen eine gesonderte Beauftragung, klare Verantwortlichkeiten, transparente Rollen und eine Finanzierungsklärung voraus.</p>
+    </section>
+
+    <section class="section split" aria-labelledby="coordination-title">
+      <div>
+        <p class="section-label">Koordination</p>
+        <h2 id="coordination-title">Gebäude, Bestand und Entwicklung zusammenführen.</h2>
+      </div>
+      <p>Bei geeigneten Fällen kann eine Planungs-, Bestands- und Entwicklungskoordination helfen, Gebäude, Grundstück, Nutzung, Sanierung, Quartier und kommunale Entwicklung zusammenzuführen, bevor einzelne Fachlösungen vertieft werden. Sie ist keine automatische Projektsteuerung, keine Generalplanung und keine Umsetzungsgarantie.</p>
     </section>
 
     <section class="section" aria-labelledby="audiences-title">
       <p class="section-label">Für wen?</p>
-      <h2 id="audiences-title">Für Akteure mit Verantwortung für Wärme, Kälte, Gebäude und Quartiere.</h2>
+      <h2 id="audiences-title">Für Akteure mit Verantwortung für Gebäude, Quartiere, Infrastruktur und Zukunftsfähigkeit.</h2>
       <div class="cards three">
         <article class="card">
           <h3>Kommunen und kommunale Unternehmen</h3>
-          <p>Für Verwaltungen, Stadtwerke und Gremien, die Liegenschaften, Quartiere, Wärmeversorgung oder Infrastruktur systematisch einordnen müssen.</p>
+          <p>Für Verwaltungen, Stadtwerke, kommunale Gesellschaften und Gremien, die Liegenschaften, Quartiere, Wärmeversorgung, Kühlung, Infrastruktur oder Standortentwicklung systematisch einordnen müssen.</p>
         </article>
         <article class="card">
           <h3>Wohnungswirtschaft und Bestandshalter</h3>
-          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen und langfristigen Investitionsentscheidungen.</p>
+          <p>Für Eigentümer, Träger und Betreiber größerer Bestände mit Sanierungszyklen, Energiefragen, Nutzungsänderungen und langfristigen Investitionsentscheidungen.</p>
         </article>
         <article class="card">
-          <h3>Gewerbe und regionale Kooperationen</h3>
-          <p>Für größere Standorte und Zusammenschlüsse, die Wärme-, Kälte-, Energie- oder Infrastrukturfragen im Zusammenhang betrachten müssen.</p>
+          <h3>Gewerbestandorte und öffentliche Gebäude</h3>
+          <p>Für größere Standorte, öffentliche Liegenschaften und Träger, bei denen Wärme, Kälte, Nutzung, Betrieb, Flächen, Infrastruktur und Sanierung zusammen betrachtet werden müssen.</p>
+        </article>
+        <article class="card">
+          <h3>Regionale Kooperationen</h3>
+          <p>Für Zusammenschlüsse, Initiativen oder regionale Arbeitszusammenhänge, die mehrere Gebäude, Standorte, Akteure oder Infrastrukturen gemeinsam betrachten wollen.</p>
+        </article>
+        <article class="card">
+          <h3>Quartiers- und Standortentwicklungen</h3>
+          <p>Für frühe Entwicklungsfragen, bei denen Gebäude, Grundstück, Nutzung, Energie, Wasserhaushalt, Aufenthaltsqualität und kommunale Ziele zusammenwirken.</p>
         </article>
       </div>
+    </section>
+
+    <section class="section split" aria-labelledby="partners-title">
+      <div>
+        <p class="section-label">Fachpartnerlogik</p>
+        <h2 id="partners-title">Fachpartner nur nach Bedarf und Freigabe.</h2>
+      </div>
+      <p>Der ZukunftsCheck ist technologieoffen und partnerneutral angelegt. Für geeignete Fragestellungen können spezialisierte Fachpartner aus Wärme, Energie, Planung und Umsetzung projektbezogen eingebunden werden. Die konkrete Einbindung erfolgt nach Bedarf, Verfügbarkeit und Freigabe. Es erfolgt keine automatische Weiterleitung an Fach-, Technologie-, Medien- oder Umsetzungspartner.</p>
     </section>
 
     <section class="section split" aria-labelledby="filter-title">
@@ -93,24 +129,24 @@
         <p class="section-label">Erstfilter</p>
         <h2 id="filter-title">Mindestdaten statt Schnellversprechen.</h2>
       </div>
-      <p>Ein späterer Erstfilter kann Organisationsart, Rolle, Objekt, Ausgangslage, Handlungsdruck, Datenlage, Zeithorizont und Entscheidungsrahmen ordnen. In dieser Staging-Fassung ist der Erstfilter ausschließlich beschreibend. Es gibt keine Eingabefelder, keinen Absenden-Button, keine Uploads und keine Datenhaltung.</p>
+      <p>Ein späterer Erstfilter kann Organisationsart, Rolle, Objekt, Ausgangslage, Handlungsdruck, Datenlage, Zeithorizont und Entscheidungsrahmen ordnen. In dieser internen Staging-Fassung ist der Erstfilter ausschließlich beschrieben. Es gibt keine Eingabefelder, keinen Absenden-Button, keine Uploads, keine Kontaktfelder und keine Datenhaltung.</p>
     </section>
 
     <section class="section governance" aria-labelledby="integrity-title">
       <p class="section-label">Datenschutz und Integrität</p>
       <h2 id="integrity-title">Klare Datenwege vor jeder Aktivierung.</h2>
-      <p>ZukunftsCheck arbeitet nur glaubwürdig, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. Eine Anfrage würde nicht automatisch an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben. Rohdaten, sensible Daten, Uploads, Tracking und automatisierte Bewertungen sind in dieser Fassung ausgeschlossen.</p>
+      <p>Der ZukunftsCheck kann nur glaubwürdig arbeiten, wenn Datenwege, Rollen und Interessen sauber getrennt bleiben. In dieser internen Staging-Fassung gibt es keine Formulare, keine Kontaktfelder, keine Uploads, keine Datenerhebung, keine sensiblen Daten, keine automatisierte Bewertung, kein Tracking und keine externen Skripte. Rohdaten werden nicht automatisch an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Interne statische Staging-Fassung auf isolierter Arbeitslinie. Keine öffentliche Website-Freigabe. Keine Formulare. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Kein Go-live.</p>
+      <p>Interne redaktionelle Staging-Fassung. Keine öffentliche Website-Freigabe. Keine Formulare. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Kein Go-live.</p>
     </section>
   </main>
 
   <footer class="site-footer">
-    <p>ZukunftsCheck · interne statische Staging-Fassung</p>
-    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Produktivschaltung</p>
+    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
   </footer>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
-  <title>ZukunftsCheck – Gebäude, Quartiere und kommunale Entwicklung</title>
+  <title>ZukunftsCheck – Orientierung vor der Technikentscheidung</title>
   <link rel="stylesheet" href="/styles/main.css">
 </head>
 <body>
@@ -17,9 +17,9 @@
 
   <main id="top">
     <section class="hero" aria-labelledby="hero-title">
-      <p class="eyebrow">Gebäude · Quartiere · Bestand · kommunale Entwicklung</p>
+      <p class="eyebrow">Leben mit der Energiewende vor Ort</p>
       <h1 id="hero-title">Orientierung vor der Technikentscheidung.</h1>
-      <p class="lead">Der ZukunftsCheck hilft, Gebäude, Grundstücke, Quartiere, Wärme- und Kältefragen sowie kommunale Entwicklungsbedarfe frühzeitig zu ordnen, bevor technische oder investive Festlegungen getroffen werden.</p>
+      <p class="lead">Der ZukunftsCheck hilft Kommunen, Stadtwerken, Bestandshaltern und größeren Standorten, Energie-, Wärme-, Kälte-, Gebäude- und Infrastrukturfragen frühzeitig zu ordnen - ohne Datenupload, ohne Projektversprechen und ohne zweite Fachplanung.</p>
     </section>
 
     <section class="section split" aria-labelledby="purpose-title">
@@ -27,18 +27,18 @@
         <p class="section-label">Zweck</p>
         <h2 id="purpose-title">Früh klären, bevor falsch entschieden wird.</h2>
       </div>
-      <p>Viele Standorte stehen vor Entscheidungen, bei denen Gebäudezustand, Nutzung, Sanierungsbedarf, Wärmeversorgung, Kühlung, Infrastruktur, Wasserhaushalt, Flächenpotenziale und kommunale Ziele zusammenwirken. Der ZukunftsCheck setzt vor der technischen Lösung an: bei Orientierung, Rollenklärung und der Frage, welche nächsten Schritte sinnvoll sind.</p>
+      <p>Der ZukunftsCheck ersetzt keine kommunale Wärmeplanung. Er hilft, vor, neben oder nach bestehenden Fachverfahren Rollen, Zuständigkeiten, Bedarf und nächste Schritte verständlich zu klären.</p>
     </section>
 
     <section class="section" aria-labelledby="check-title">
       <p class="section-label">Was wird geprüft?</p>
       <h2 id="check-title">Der ZukunftsCheck ordnet die frühe Ausgangslage.</h2>
-      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Bedarf, Datenstand, Zuständigkeiten, Risiken und nächste Schritte ausreichend klar sind.</p>
+      <p class="section-intro">Im Mittelpunkt steht nicht der Verkauf einer bestimmten Technologie, sondern die Frage, ob Bedarf, Informationsstand, Zuständigkeiten, Risiken und nächste Schritte ausreichend klar sind.</p>
       <div class="cards three">
         <article class="card">
           <span class="card-number">01</span>
-          <h3>Bestand, Nutzung und Bedarf</h3>
-          <p>Gebäude, Nutzung, Wärme- und Kältebedarf, Sanierungsstand, bekannte Planungen und offene Fragen werden als Ausgangslage geordnet.</p>
+          <h3>Bestand, Nutzung und Fragestellung</h3>
+          <p>Gebäude, Nutzung, Wärme- und Kältefragen, Sanierungsstand, bekannte Planungen und offene Punkte werden als Ausgangslage geordnet.</p>
         </article>
         <article class="card">
           <span class="card-number">02</span>
@@ -47,8 +47,8 @@
         </article>
         <article class="card">
           <span class="card-number">03</span>
-          <h3>Energie, Wärme, Kälte und Infrastruktur</h3>
-          <p>Versorgungssysteme, Energiebedarf und Schnittstellen zu Sanierung, Betrieb und Planung werden technologieoffen sichtbar gemacht.</p>
+          <h3>Energie, Wärme, Kälte und Schnittstellen</h3>
+          <p>Versorgungsfragen und Schnittstellen zu Sanierung, Betrieb, Planung und Infrastruktur werden technologieoffen sichtbar gemacht.</p>
         </article>
         <article class="card">
           <span class="card-number">04</span>
@@ -58,26 +58,27 @@
         <article class="card">
           <span class="card-number">05</span>
           <h3>Entscheidungsrahmen</h3>
-          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, Datenlücken und nächste Prüfschritte werden sichtbar.</p>
+          <p>Zuständigkeiten, Mandat, Zeithorizont, Entscheidungsdruck, offene Punkte und nächste Prüfschritte werden sichtbar.</p>
         </article>
       </div>
     </section>
 
     <section class="section process" aria-labelledby="process-title">
       <p class="section-label">Arbeitsweise</p>
-      <h2 id="process-title">Vom Interesse zur Erstklärung.</h2>
+      <h2 id="process-title">Vom Interesse zur geordneten Erstklärung.</h2>
       <ol class="steps">
-        <li><span>1</span>Interesse und Ausgangsfrage klären</li>
-        <li><span>2</span>Rolle, Zuständigkeit und Ziel einordnen</li>
-        <li><span>3</span>Gebäude, Bestand oder Quartier grob verorten</li>
-        <li><span>4</span>Offene Fragen und mögliche nächste Schritte sichtbar machen</li>
+        <li><span>1</span>Anlass und Ausgangsfrage klären</li>
+        <li><span>2</span>Rolle und Zuständigkeit einordnen</li>
+        <li><span>3</span>Grobes Themenfeld sortieren</li>
+        <li><span>4</span>Sinnvolle nächste Schritte festhalten</li>
       </ol>
-      <p>Der ZukunftsCheck schafft Orientierung für das weitere Vorgehen. Eine fachliche Vertiefung oder Umsetzung entsteht daraus nicht automatisch. Bei Bedarf können spezialisierte Fachleute erst nach Klärung von Bedarf, Rolle und Freigabe hinzugezogen werden.</p>
+      <p>Der Einstieg beginnt mit einer kurzen Erstklärung. Zunächst werden Anlass, Rolle, Zuständigkeit und grobes Themenfeld geklärt. Erst danach wird entschieden, ob und welche fachliche Vertiefung sinnvoll ist.</p>
     </section>
 
     <section class="section" aria-labelledby="audiences-title">
       <p class="section-label">Für wen?</p>
       <h2 id="audiences-title">Für Akteure mit Verantwortung für Gebäude, Quartiere, Infrastruktur und Zukunftsfähigkeit.</h2>
+      <p class="section-intro">Der ZukunftsCheck richtet sich an Kommunen, Stadtwerke, Bestandshalter, öffentliche Träger, Unternehmen, Einrichtungen und größere Standorte, die Energie-, Wärme-, Kälte-, Gebäude- oder Infrastrukturfragen frühzeitig einordnen wollen.</p>
       <div class="cards three">
         <article class="card">
           <h3>Kommunen und kommunale Unternehmen</h3>
@@ -105,20 +106,20 @@
     <section class="section split" aria-labelledby="start-title">
       <div>
         <p class="section-label">Nächster Schritt</p>
-        <h2 id="start-title">Erstklärung statt Dateneingabe.</h2>
+        <h2 id="start-title">Erstklärung statt Datenupload.</h2>
       </div>
-      <p>Der ZukunftsCheck beginnt nicht mit einer Dateneingabe, sondern mit einer kurzen Erstklärung. Dabei wird besprochen, worum es geht, wer zuständig ist und welche Informationen später überhaupt benötigt werden. Gebäude-, Verbrauchs-, Mieter-, Eigentümer-, Planungs- oder sonstige Projektdaten werden nicht über die Website erhoben.</p>
+      <p>Die allgemeine Landingpage erhebt keine Projekt-, Gebäude-, Verbrauchs-, Mieter-, Eigentümer-, Planungs- oder Infrastrukturdaten. Eine Formularintegration bleibt gesondert freigabepflichtig.</p>
     </section>
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Interne redaktionelle Staging-Fassung. Keine öffentliche Website-Freigabe. Keine Formulare. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Kein Go-live.</p>
+      <p>Interne Staging-Fassung. Keine Formulare. Keine Uploads. Keine Datenerhebung. Kein Tracking. Keine Partnerdarstellung. Keine Produktivschaltung.</p>
     </section>
   </main>
 
   <footer class="site-footer">
     <p><a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a></p>
-    <p>ZukunftsCheck · interne redaktionelle Staging-Fassung</p>
+    <p>ZukunftsCheck · interne Staging-Fassung</p>
     <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Partnerdarstellung · keine Produktivschaltung</p>
   </footer>
 </body>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,90 +1,276 @@
 :root {
-  --blue: #11384f;
-  --teal: #1aa6a6;
-  --bg: #f7fbfb;
-  --card: #ffffff;
-  --text: #18313f;
-  --muted: #5b6f7a;
-  --line: #d6e5e5;
+  --ink: #102f43;
+  --ink-soft: #315163;
+  --petrol: #0f7f86;
+  --petrol-soft: #dcefee;
+  --sand: #f4efe7;
+  --paper: #fffdf8;
+  --mist: #eef6f4;
+  --line: #d7e3df;
+  --shadow: 0 22px 70px rgba(16, 47, 67, 0.10);
 }
 
 * { box-sizing: border-box; }
-
+html { scroll-behavior: smooth; }
 body {
   margin: 0;
-  min-height: 100vh;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: var(--text);
+  color: var(--ink);
   background:
-    radial-gradient(circle at 92% 8%, rgba(121, 173, 188, 0.24), transparent 30%),
-    radial-gradient(circle at 15% 95%, rgba(115, 176, 166, 0.18), transparent 28%),
-    var(--bg);
+    radial-gradient(circle at top right, rgba(15, 127, 134, 0.16), transparent 32rem),
+    linear-gradient(180deg, var(--paper), var(--mist));
 }
 
-.shell {
-  width: min(1080px, calc(100% - 40px));
-  margin: 0 auto;
-  padding: 80px 0;
+.site-header,
+.site-footer,
+.hero,
+.section,
+.status-band {
+  width: min(1120px, calc(100% - 40px));
+  margin-inline: auto;
 }
 
-.eyebrow {
-  margin: 0 0 12px;
-  color: var(--teal);
-  font-weight: 700;
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  padding: 28px 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  color: white;
+  background: var(--ink);
+  font-size: 0.92rem;
+}
+
+.stage-pill {
+  margin: 0;
+  padding: 9px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.hero {
+  padding: clamp(56px, 9vw, 112px) 0 56px;
+}
+
+.eyebrow,
+.section-label {
+  margin: 0 0 14px;
+  color: var(--petrol);
+  font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  font-size: 0.82rem;
 }
 
+h1,
+h2,
+h3 {
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
+}
+
+p { overflow-wrap: break-word; }
+
 h1 {
+  max-width: 980px;
   margin: 0;
-  color: var(--blue);
-  font-size: clamp(3rem, 8vw, 6.5rem);
+  font-size: clamp(2.7rem, 7.4vw, 6.9rem);
   line-height: 0.95;
+  letter-spacing: -0.065em;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3.4vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+h3 {
+  margin: 16px 0 10px;
+  font-size: 1.35rem;
+  line-height: 1.15;
 }
 
 .lead {
-  max-width: 820px;
-  margin: 24px 0 40px;
-  font-size: clamp(1.25rem, 2.4vw, 2rem);
+  max-width: 760px;
+  margin: 28px 0 0;
+  color: var(--ink-soft);
+  font-size: clamp(1.2rem, 2.2vw, 1.75rem);
+  line-height: 1.42;
+}
+
+.hero-status,
+.status-band,
+.card,
+.governance {
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: var(--shadow);
+}
+
+.hero-status {
+  max-width: 780px;
+  margin-top: 34px;
+  padding: 18px 20px;
+  color: var(--ink-soft);
+}
+
+.section {
+  padding: 70px 0;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: clamp(28px, 6vw, 72px);
+  align-items: start;
+}
+
+.split > p,
+.governance p,
+.status-band p,
+.card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 1.06rem;
+  line-height: 1.65;
+}
+
+.cards {
+  display: grid;
+  gap: 20px;
+  margin-top: 30px;
+}
+
+.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+.card {
+  padding: 28px;
+}
+
+.card-number {
+  display: inline-flex;
+  color: var(--petrol);
+  font-weight: 900;
+}
+
+.process {
+  padding-top: 40px;
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 30px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.steps li {
+  min-height: 150px;
+  padding: 22px;
+  border-radius: 24px;
+  background: var(--ink);
+  color: white;
+  font-weight: 700;
   line-height: 1.35;
 }
 
-.notice,
-.grid article {
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 24px;
-  box-shadow: 0 18px 45px rgba(17, 56, 79, 0.08);
+.steps span {
+  display: block;
+  margin-bottom: 22px;
+  color: #9fd7d5;
 }
 
-.notice {
+.governance {
+  padding: clamp(28px, 5vw, 54px);
+  background: linear-gradient(135deg, #ffffff, var(--petrol-soft));
+}
+
+.governance p { max-width: 820px; margin-top: 18px; }
+
+.status-band {
+  margin-top: 30px;
+  margin-bottom: 60px;
   padding: 28px;
-  border-left: 6px solid var(--teal);
+  background: var(--sand);
 }
 
-.notice h2,
-.grid h2 {
-  margin: 0 0 10px;
-  color: var(--blue);
+.status-band h2 {
+  font-size: clamp(1.5rem, 3vw, 2.4rem);
 }
 
-.notice p,
-.grid p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.55;
+.status-band p { margin-top: 10px; }
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 34px 0 48px;
+  border-top: 1px solid var(--line);
+  color: var(--ink-soft);
+  font-size: 0.92rem;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 20px;
-  margin-top: 24px;
+.site-footer p { margin: 0; }
+
+@media (max-width: 880px) {
+  .site-header,
+  .site-footer,
+  .split { grid-template-columns: 1fr; flex-direction: column; align-items: flex-start; }
+  .three,
+  .steps { grid-template-columns: 1fr; }
+  .section { padding: 48px 0; }
+  .section.governance { padding: 32px 24px; }
+  .steps li { min-height: auto; }
+  h1 {
+    font-size: clamp(2.35rem, 10.5vw, 4.6rem);
+    letter-spacing: -0.052em;
+  }
 }
 
-.grid article { padding: 24px; }
-
-@media (max-width: 820px) {
-  .shell { padding: 48px 0; }
-  .grid { grid-template-columns: 1fr; }
+@media (max-width: 520px) {
+  .site-header,
+  .site-footer,
+  .hero,
+  .section,
+  .status-band {
+    width: min(100% - 28px, 1120px);
+  }
+  .section.governance { padding: 28px 20px; }
+  h1 {
+    font-size: clamp(2.1rem, 11.2vw, 3.2rem);
+    line-height: 1;
+    letter-spacing: -0.04em;
+  }
+  h2 {
+    font-size: clamp(1.85rem, 9vw, 2.75rem);
+    line-height: 1.08;
+  }
+  .stage-pill { border-radius: 18px; }
 }


### PR DESCRIPTION
ZS-WEB-020 – Landingpage v0.3.3 Frank-Vorzeigestand

Status: geschlossen und gemerged. Dieser PR dokumentiert den früheren Frank-Vorzeigestand auf main. Keine aktuelle Freigabe für neue Website-Änderungen, kein neuer Go-live und keine Ableitung für ZS-WEB-NEUTRAL-002.

Hinweis 09.07.2026: Die weitere Neutralisierung erfolgt separat auf der Branch `zs-web-neutral-v032-staging` im Arbeitsblock ZS-WEB-NEUTRAL-002.