### PR TITLE
Raumfunktions-Minimalfassung in die ZukunftsCheck-Landingpage integrieren

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,14 @@
       <p>Der ZukunftsCheck hilft, frühe Fragen zu Gebäuden, Quartieren, Standorten, Wärme, Kälte, Nutzung, Sanierung und kommunaler Entwicklung verständlich zu ordnen, bevor technische, planerische oder investive Festlegungen getroffen werden.</p>
     </section>
 
+    <section class="section split" aria-labelledby="space-teaser-title">
+      <div>
+        <p class="section-label">Räumliche Zusammenhänge früh erkennen</p>
+        <h2 id="space-teaser-title">Räume sind nicht nur Flächen.</h2>
+      </div>
+      <p>Sie speichern Wasser, mindern Hitze, tragen Vegetation und ermöglichen räumliche Verbindungen und Regeneration. Bei Vorhaben mit relevantem Flächenbezug kann der ZukunftsCheck frühzeitig sichtbar machen, welche Funktionen berücksichtigt und fachlich vertieft geprüft werden sollten.</p>
+    </section>
+
     <section class="section" aria-labelledby="value-title">
       <p class="section-label">Was der ZukunftsCheck leistet</p>
       <h2 id="value-title">Er schafft Orientierung, bevor Fachplanung, technische Beratung oder Umsetzung beginnen.</h2>
@@ -115,6 +123,21 @@
       <p>Zeigt sich, dass eine Frage technische Planung, Energieberatung, Wirtschaftlichkeit, Förderung, Projektentwicklung oder Umsetzung betrifft, wird sie als späterer Fachpunkt markiert. So bleibt die Erstklärung neutral und der nächste Schritt nachvollziehbar.</p>
     </section>
 
+    <section class="section" aria-labelledby="space-functions-title">
+      <p class="section-label">Optionaler Baustein bei relevantem Flächenbezug</p>
+      <h2 id="space-functions-title">Räume erfüllen Funktionen.</h2>
+      <p class="section-intro">Kommunale und infrastrukturelle Entscheidungen betreffen nicht nur einzelne Grundstücke, Gebäude oder technische Anlagen. Sie können zugleich den Wasserhaushalt, die Kühlungswirkung, Vegetationsstrukturen, räumliche und ökologische Verbindungen sowie die Regenerationsfähigkeit eines Gebiets beeinflussen.</p>
+      <p>Bei Vorhaben mit relevantem Flächenbezug kann deshalb innerhalb der Erstklärung des ZukunftsChecks ein qualitatives Raumfunktionsscreening eingesetzt werden. Auf Grundlage vorhandener Unterlagen hilft es dabei, frühzeitig zu strukturieren,</p>
+      <ul>
+        <li>welche räumlichen Funktionen erkennbar oder voraussichtlich relevant sind,</li>
+        <li>welche Teilräume möglicherweise unterschiedlich betrachtet werden müssen,</li>
+        <li>wo wesentliche Informationen fehlen,</li>
+        <li>welche möglichen Zielkonflikte, Risiken oder Entwicklungsmöglichkeiten vertieft geprüft werden sollten,</li>
+        <li>und welche fachlichen Prüfungen oder Planungsleistungen anschließend erforderlich sind.</li>
+      </ul>
+      <p>Das Raumfunktionsscreening ersetzt keine Fachplanung, Umweltprüfung oder hydrologische, bodenkundliche, klimatische, naturschutzfachliche, rechtliche oder genehmigungsbezogene Prüfung. Es dient der frühen Orientierung und Strukturierung, damit relevante räumliche Zusammenhänge nicht erst sichtbar werden, nachdem grundlegende Entscheidungen bereits getroffen wurden.</p>
+    </section>
+
     <section class="section split" aria-labelledby="info-title">
       <div>
         <p class="section-label">Welche Informationen genügen</p>
@@ -159,13 +182,13 @@
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Interne Staging-Fassung v0.3.2. Keine Formulare. Keine Uploads. Keine Datenerhebung. Kein Tracking. Keine Anbieterstrecke. Keine Produktivschaltung.</p>
+      <p>Interne Staging-Fassung v0.3.3. Keine Formulare. Keine Uploads. Keine Datenerhebung. Kein Tracking. Keine Anbieterstrecke. Keine Produktivschaltung.</p>
     </section>
   </main>
 
   <footer class="site-footer">
     <p><a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a></p>
-    <p>ZukunftsCheck · interne Staging-Fassung v0.3.2</p>
+    <p>ZukunftsCheck · interne Staging-Fassung v0.3.3</p>
     <p>Keine Formulare · keine Uploads · keine Datenerhebung · kein Tracking · keine Anbieterstrecke · keine Produktivschaltung</p>
   </footer>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
         <p class="section-label">Räumliche Zusammenhänge früh erkennen</p>
         <h2 id="space-teaser-title">Räume sind nicht nur Flächen.</h2>
       </div>
-      <p>Sie speichern Wasser, mindern Hitze, tragen Vegetation und ermöglichen räumliche Verbindungen und Regeneration. Bei Vorhaben mit relevantem Flächenbezug kann der ZukunftsCheck frühzeitig sichtbar machen, welche Funktionen berücksichtigt und fachlich vertieft geprüft werden sollten.</p>
+      <p>Wasser, Hitze, Vegetation und räumliche Verbindungen können bei frühen Entscheidungen eine wichtige Rolle spielen. Der ZukunftsCheck hilft zunächst zu klären, welche Fragen später fachlich geprüft werden müssen.</p>
     </section>
 
     <section class="section" aria-labelledby="value-title">
@@ -123,19 +123,12 @@
       <p>Zeigt sich, dass eine Frage technische Planung, Energieberatung, Wirtschaftlichkeit, Förderung, Projektentwicklung oder Umsetzung betrifft, wird sie als späterer Fachpunkt markiert. So bleibt die Erstklärung neutral und der nächste Schritt nachvollziehbar.</p>
     </section>
 
-    <section class="section" aria-labelledby="space-functions-title">
-      <p class="section-label">Optionaler Baustein bei relevantem Flächenbezug</p>
-      <h2 id="space-functions-title">Räume erfüllen Funktionen.</h2>
-      <p class="section-intro">Kommunale und infrastrukturelle Entscheidungen betreffen nicht nur einzelne Grundstücke, Gebäude oder technische Anlagen. Sie können zugleich den Wasserhaushalt, die Kühlungswirkung, Vegetationsstrukturen, räumliche und ökologische Verbindungen sowie die Regenerationsfähigkeit eines Gebiets beeinflussen.</p>
-      <p>Bei Vorhaben mit relevantem Flächenbezug kann deshalb innerhalb der Erstklärung des ZukunftsChecks ein qualitatives Raumfunktionsscreening eingesetzt werden. Auf Grundlage vorhandener Unterlagen hilft es dabei, frühzeitig zu strukturieren,</p>
-      <ul>
-        <li>welche räumlichen Funktionen erkennbar oder voraussichtlich relevant sind,</li>
-        <li>welche Teilräume möglicherweise unterschiedlich betrachtet werden müssen,</li>
-        <li>wo wesentliche Informationen fehlen,</li>
-        <li>welche möglichen Zielkonflikte, Risiken oder Entwicklungsmöglichkeiten vertieft geprüft werden sollten,</li>
-        <li>und welche fachlichen Prüfungen oder Planungsleistungen anschließend erforderlich sind.</li>
-      </ul>
-      <p>Das Raumfunktionsscreening ersetzt keine Fachplanung, Umweltprüfung oder hydrologische, bodenkundliche, klimatische, naturschutzfachliche, rechtliche oder genehmigungsbezogene Prüfung. Es dient der frühen Orientierung und Strukturierung, damit relevante räumliche Zusammenhänge nicht erst sichtbar werden, nachdem grundlegende Entscheidungen bereits getroffen wurden.</p>
+    <section class="section split" aria-labelledby="space-functions-title">
+      <div>
+        <p class="section-label">Räumliche Prüfperspektive</p>
+        <h2 id="space-functions-title">Räume erfüllen Funktionen.</h2>
+      </div>
+      <p>Bei Entscheidungen über Gebäude, Standorte, Quartiere oder Infrastruktur können auch räumliche Zusammenhänge eine Rolle spielen – etwa Wasserhaushalt, Hitzeminderung, Vegetation oder Verbindungen zwischen Teilräumen. Der ZukunftsCheck kann solche Fragen frühzeitig als möglichen Klärungsbedarf sichtbar machen. Fachliche Bewertung, Planung und Prüfung bleiben Aufgabe der jeweils zuständigen Fachstellen.</p>
     </section>
 
     <section class="section split" aria-labelledby="info-title">


### PR DESCRIPTION
## Was geändert wurde

- freigegebener Teaser „Räume sind nicht nur Flächen“ in die bestehende Seitendarstellung eingefügt
- freigegebener Haupttext „Räume erfüllen Funktionen“ nach der Ablaufdarstellung ergänzt
- interne Staging-Kennzeichnung auf v0.3.3 fortgeschrieben

## Warum

Die räumliche Prüfperspektive soll im ZukunftsCheck früh sichtbar werden, ohne daraus ein eigenständiges Produkt, eine Screening-Methode oder eine Fachprüfung abzuleiten.

## Abgrenzung

Nicht enthalten sind:

- Methodenname oder Produktbezeichnung
- Unterlagensichtung
- Prüflisten
- fachliche Bewertung oder Planung
- Formulare, Uploads, Tracking oder Anbieterlogik
- Deployment oder Go-live

## Validierung

Die korrigierte Minimalfassung wurde intern in Chromium geprüft bei:

- Desktop: 1440 px
- Tablet: 820 px
- Mobil: 390 px

Ergebnis: keine Überläufe, keine abgeschnittenen Inhalte, saubere Typografie und responsive Einfügung in die vorhandene Seitenlogik.

## Formelle Freigabeprüfung

Die Sichtprüfung wurde durch Hans Leo Bader bestätigt. Der Pull Request ist mergefähig und wurde aus dem Draft-Status in „Ready for review“ überführt.

## Verbleibende Freigabegrenze

Noch nicht erfolgt sind:

- Merge nach main
- produktives Deployment
- Go-live

Diese Schritte bedürfen weiterhin einer gesonderten Entscheidung.