### PR TITLE
ZS-WEB-024: Getrennte Beitrags- und Kontaktformulare aktivieren

### DIFF
--- a/api/submit.js
+++ b/api/submit.js
@@ -1,0 +1,56 @@
+const nodemailer = require('nodemailer');
+
+const LIMITS = { text:10000, topic:300, source:500, location:300, perspective:1000, name:200, email:320, phone:100, organization:300, organizationType:200, preferred:100, purpose:300, message:3000, eventContext:100, type:200 };
+const clean = (value, key) => String(value ?? '').replace(/\0/g, '').trim().slice(0, LIMITS[key] || 500);
+const validEmail = value => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) && value.length <= 320;
+const lines = fields => Object.entries(fields).filter(([,v]) => v && (!Array.isArray(v) || v.length)).map(([k,v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`).join('\n\n');
+const attempts = new Map();
+
+function allowedOrigin(origin) {
+  try {
+    const host = new URL(origin).hostname;
+    return host === 'zukunftscheck.org' || host === 'www.zukunftscheck.org' || host.endsWith('.vercel.app');
+  } catch { return false; }
+}
+
+module.exports = async function handler(req, res) {
+  res.setHeader('Cache-Control', 'no-store');
+  if (req.method !== 'POST') return res.status(405).json({ok:false,message:'Methode nicht zulässig.'});
+  if (!req.headers['content-type']?.includes('application/json')) return res.status(415).json({ok:false,message:'Ungültiges Datenformat.'});
+  if (!allowedOrigin(req.headers.origin)) return res.status(403).json({ok:false,message:'Anfrage nicht zulässig.'});
+  const client = String(req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown').split(',')[0].trim();
+  const now = Date.now(), recent = (attempts.get(client) || []).filter(time => now-time < 600000);
+  if (recent.length >= 5) return res.status(429).json({ok:false,message:'Zu viele Anfragen. Bitte versuchen Sie es später erneut.'});
+  recent.push(now); attempts.set(client,recent);
+  const body = req.body || {};
+  if (body.website) return res.status(200).json({ok:true,message:'Vielen Dank.'});
+  const started = Number(body.formStartedAt);
+  if (!Number.isFinite(started) || Date.now()-started < 2000 || Date.now()-started > 86400000) return res.status(400).json({ok:false,message:'Bitte laden Sie die Seite neu und versuchen Sie es erneut.'});
+  const formType = ['contribution','contact'].includes(body.formType) ? body.formType : '';
+  const eventContext = clean(body.eventContext,'eventContext');
+  if (!formType || !eventContext || body.privacy !== true) return res.status(400).json({ok:false,message:'Bitte füllen Sie alle Pflichtfelder aus.'});
+
+  let subject, content, replyTo;
+  if (formType === 'contribution') {
+    const text=clean(body.text,'text'), type=clean(body.type,'type');
+    if (!text || !type) return res.status(400).json({ok:false,message:'Beitragstext und Beitragsart sind erforderlich.'});
+    subject=`ZukunftsCheck – neuer fachlicher Beitrag – ${eventContext}`;
+    content=lines({'Datenweg':'Fachlicher Beitrag','Veranstaltungskennung':eventContext,'Beitragsart':type,'Beitrag':text,'Thema':clean(body.topic,'topic'),'Quellenangabe':clean(body.source,'source'),'Fundstelle':clean(body.location,'location'),'Betroffenheit/Perspektive':clean(body.perspective,'perspective')});
+  } else {
+    const name=clean(body.name,'name'), email=clean(body.email,'email'), purpose=clean(body.purpose,'purpose');
+    if (!name || !validEmail(email) || !purpose) return res.status(400).json({ok:false,message:'Name, gültige E-Mail-Adresse und Kontaktzweck sind erforderlich.'});
+    replyTo=email;
+    const interests=Array.isArray(body.interest)?body.interest.map(v=>clean(v,'type')).slice(0,12):[];
+    subject=`ZukunftsCheck – neue Kontaktanfrage – ${eventContext}`;
+    content=lines({'Datenweg':'Kontakt','Veranstaltungskennung':eventContext,'Kontaktzweck':purpose,'Name':name,'E-Mail':email,'Telefon':clean(body.phone,'phone'),'Organisation':clean(body.organization,'organization'),'Organisationstyp':clean(body.organizationType,'organizationType'),'Interessen':interests,'Bevorzugter Kontaktweg':clean(body.preferred,'preferred'),'Nachricht':clean(body.message,'message')});
+  }
+  if (!process.env.GMAIL_USER || !process.env.GMAIL_APP_PASSWORD || !process.env.MAIL_TO) return res.status(503).json({ok:false,message:'Der Versand ist vorübergehend nicht verfügbar.'});
+  try {
+    const transporter=nodemailer.createTransport({host:'smtp.gmail.com',port:465,secure:true,auth:{user:process.env.GMAIL_USER,pass:process.env.GMAIL_APP_PASSWORD}});
+    await transporter.sendMail({from:`ZukunftsCheck Website <${process.env.GMAIL_USER}>`,to:process.env.MAIL_TO,replyTo,subject,text:`${content}\n\nEingegangen: ${new Date().toISOString()}\nQuelle: www.zukunftscheck.org`});
+    return res.status(200).json({ok:true,message:'Vielen Dank. Ihre Angaben wurden übermittelt.'});
+  } catch (error) {
+    console.error('Mailversand fehlgeschlagen',error?.code||error?.message||'unbekannt');
+    return res.status(502).json({ok:false,message:'Die Übermittlung ist fehlgeschlagen. Bitte versuchen Sie es später erneut.'});
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "zukunftscheck-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zukunftscheck-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "nodemailer": "^9.0.3"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "test": "node tests/preview-check.mjs",
     "build": "echo \"Static shell: no build step required.\""
+  },
+  "dependencies": {
+    "nodemailer": "^9.0.3"
   }
 }

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -18,7 +18,7 @@
       <a href="/index.html">Start</a><a href="/teilnahme.html">Beteiligung</a><a href="/veranstaltung-hamm.html">Veranstaltung</a><a aria-current="page" href="/datenschutz.html">Datenschutz</a>
     </nav>
   </header>
-  <div class="preview-bar" role="status">Veröffentlichungsvorbereitung · Online-Formulare sind noch nicht aktiv</div>
+  <div class="preview-bar" role="status">Öffentliche Informations- und Beteiligungsseite · Übermittlung verschlüsselt</div>
 
   <main id="main" class="legal-main">
     <section class="hero legal-hero" aria-labelledby="hero-title">
@@ -52,7 +52,7 @@
     <section class="legal-card legal-card-wide" aria-labelledby="purposes-title">
       <p class="section-label">3. Zwecke und Rechtsgrundlagen</p>
       <h2 id="purposes-title">Technische Bereitstellung der Website</h2>
-      <p>Die für Webfreigabe A vorbereitete Fassung verarbeitet keine Formularangaben, keine Uploads und keine aktiv eingegebenen personenbezogenen Daten. Beim Aufruf der Website können technisch notwendige Zugriffsdaten verarbeitet werden, insbesondere IP-Adresse, Datum und Uhrzeit des Abrufs, angeforderte Datei, übertragene Datenmenge, Browser- und Betriebssysteminformationen sowie Referrer-URL, soweit dies zur Bereitstellung, Sicherheit und Stabilität der Website erforderlich ist.</p>
+      <p>Beim Aufruf der Website können technisch notwendige Zugriffsdaten verarbeitet werden, insbesondere IP-Adresse, Datum und Uhrzeit des Abrufs, angeforderte Datei, übertragene Datenmenge, Browser- und Betriebssysteminformationen sowie Referrer-URL, soweit dies zur Bereitstellung, Sicherheit und Stabilität der Website erforderlich ist.</p>
       <p>Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Unser berechtigtes Interesse liegt in der sicheren, stabilen und missbrauchsarmen Bereitstellung der Website.</p>
     </section>
 
@@ -66,10 +66,12 @@
     </section>
 
     <section class="legal-card" aria-labelledby="no-tracking-title">
-      <p class="section-label">5. Keine Formulare, kein Tracking</p>
-      <h2 id="no-tracking-title">Keine aktive Datenerhebung</h2>
-      <p>Die Website informiert über geplante Beteiligungs- und Kontaktwege. Die Eingabeformulare sind bis zu einer gesonderten Formularfreigabe B vollständig ausgeblendet und nicht aktiv. Es bestehen keine Upload-Funktion, Newsletter-Anmeldung, Zahlungsfunktion, eingebetteten Karten, Video-Embeds, Analyse- oder Werbetracking-Dienste und keine automatische Partnervermittlung.</p>
-      <p>Es werden keine personenbezogenen Daten an Fach-, Technologie-, Medien- oder Umsetzungspartner weitergegeben.</p>
+      <p class="section-label">5. Beiträge und Kontaktanfragen</p>
+      <h2 id="no-tracking-title">Getrennte Formularwege</h2>
+      <p>Das Formular „Fachlicher Beitrag“ kann ohne Name, E-Mail-Adresse oder Telefonnummer verwendet werden. Verarbeitet werden der gewählte Veranstaltungsbezug, Beitragstext, Beitragsart und freiwillige fachliche Zusatzangaben. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO; das berechtigte Interesse liegt in der nachvollziehbaren Entgegennahme fachlicher Hinweise und Fragen.</p>
+      <p>Beim freiwilligen Kontaktformular werden Kontaktzweck, Name, E-Mail-Adresse sowie freiwillig Telefon, Organisation, Interessen, bevorzugter Kontaktweg und Nachricht verarbeitet. Die Verarbeitung erfolgt zur Bearbeitung Ihrer Anfrage auf Grundlage von Art. 6 Abs. 1 lit. b DSGVO, soweit sie vorvertraglichen Maßnahmen dient, im Übrigen auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO.</p>
+      <p>Beide Datenwege werden getrennt versendet. Die Angaben werden über eine geschützte Serverfunktion per Gmail an Media International Bader übermittelt. Dabei verarbeitet Google die E-Mail-Daten zur technischen Zustellung. Eine Übermittlung in Drittländer kann nicht ausgeschlossen werden. Weitere Informationen enthält die <a href="https://policies.google.com/privacy?hl=de">Datenschutzerklärung von Google</a>.</p>
+      <p>Es bestehen keine Upload-Funktion, Newsletter-Anmeldung, Zahlungsfunktion, eingebetteten Karten, Video-Embeds, Analyse- oder Werbetracking-Dienste und keine automatische Partnervermittlung.</p>
     </section>
 
     <section class="legal-card" aria-labelledby="cookies-title">
@@ -86,7 +88,7 @@
         <p class="section-label">7. Speicherdauer</p>
         <h2 id="duration-title">Speicherung technischer Zugriffsdaten</h2>
       </div>
-      <p>Technische Zugriffsdaten werden nur so lange gespeichert, wie dies für Bereitstellung, Sicherheit, Fehleranalyse und Missbrauchserkennung erforderlich ist. Konkrete Speicherfristen hängen vom eingesetzten Hosting-Dienstleister ab und sind vor einer öffentlichen Produktivschaltung final zu prüfen.</p>
+      <p>Technische Zugriffsdaten werden nur so lange gespeichert, wie dies für Bereitstellung, Sicherheit, Fehleranalyse und Missbrauchserkennung erforderlich ist. Formularnachrichten werden im empfangenden E-Mail-Postfach nur so lange aufbewahrt, wie dies zur Bearbeitung, Dokumentation und Erfüllung gesetzlicher Aufbewahrungspflichten erforderlich ist.</p>
     </section>
 
     <section class="legal-card legal-card-wide" aria-labelledby="rights-title">
@@ -109,14 +111,14 @@
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Veröffentlichungsvorbereitung für Webfreigabe A. Hosting-Vertragspartei, Verarbeitungsorte, Auftragsverarbeitung und konkrete Logdatenfristen sind noch Freigabeblocker und werden nicht als geklärt dargestellt.</p>
+      <p>Informationsseite und getrennte Formularwege sind technisch vorbereitet. Es werden keine Dateien hochgeladen, keine Beiträge öffentlich angezeigt und keine automatische Bewertung oder Weitergabe an Fachpartner vorgenommen.</p>
     </section>
   </main>
 
   <footer class="site-footer">
     <p><a href="/">Startseite</a> · <a href="/datenschutz.html" aria-current="page">Datenschutz</a> · <a href="/impressum.html">Impressum</a></p>
-    <p>ZukunftsCheck · Informationsangebot</p>
-    <p>Online-Formulare noch nicht aktiv · keine Uploads · kein Tracking</p>
+    <p>ZukunftsCheck · Informations- und Beteiligungsangebot</p>
+    <p>Keine Uploads · kein Tracking</p>
   </footer>
 </body>
 </html>

--- a/public/preview.js
+++ b/public/preview.js
@@ -1,1 +1,48 @@
-(()=>{const events=window.ZS_EVENTS||[];const params=new URLSearchParams(location.search);const requested=params.get('event');let active=events.find(x=>x.id===requested)||events[0];const $a=s=>[...document.querySelectorAll(s)];function paint(){document.querySelectorAll('[data-context-label]').forEach(e=>e.textContent=active.label);document.querySelectorAll('[data-context-id]').forEach(e=>e.textContent=active.id);document.querySelectorAll('[name=eventContext]').forEach(e=>e.value=active.id);$a('[data-event-card]').forEach(e=>e.classList.toggle('selected',e.dataset.eventCard===active.id));$a('[data-event-select]').forEach(e=>e.checked=e.value===active.id)}$a('[data-event-select]').forEach(e=>e.addEventListener('change',()=>{active=events.find(x=>x.id===e.value)||events[0];paint()}));$a('form[data-preview-form]').forEach(form=>form.addEventListener('submit',event=>{event.preventDefault();if(!form.reportValidity())return;const target=form.querySelector('[data-preview-result]');target.hidden=false;target.innerHTML=`<strong>Vorschaufunktion:</strong> Das Formular übermittelt und speichert derzeit keine Daten.<br>Gewählter Bezug: ${active.label}<br>Kennung: ${active.id}`;target.focus()}));paint();const section=params.get('section')||location.hash.slice(1);if(section)requestAnimationFrame(()=>document.getElementById(section)?.scrollIntoView())})();
+(()=>{
+  const events=window.ZS_EVENTS||[];
+  const params=new URLSearchParams(location.search);
+  let active=events.find(x=>x.id===params.get('event'))||events[0];
+  const all=s=>[...document.querySelectorAll(s)];
+  function paint(){
+    document.querySelectorAll('[data-context-label]').forEach(e=>e.textContent=active.label);
+    document.querySelectorAll('[data-context-id]').forEach(e=>e.textContent=active.id);
+    document.querySelectorAll('[name=eventContext]').forEach(e=>e.value=active.id);
+    all('[data-event-card]').forEach(e=>e.classList.toggle('selected',e.dataset.eventCard===active.id));
+    all('[data-event-select]').forEach(e=>e.checked=e.value===active.id);
+  }
+  function initializeForm(form){
+    form.elements.formStartedAt.value=Date.now();
+    form.addEventListener('submit',async event=>{
+      event.preventDefault();
+      if(!form.reportValidity())return;
+      const target=form.querySelector('[data-preview-result]');
+      const button=form.querySelector('button[type=submit]');
+      button.disabled=true;
+      target.hidden=false;
+      target.textContent='Ihre Angaben werden übermittelt …';
+      target.focus();
+      const data={};
+      new FormData(form).forEach((value,key)=>{
+        if(key==='interest'){data[key]??=[];data[key].push(value)}else data[key]=value;
+      });
+      data.privacy=form.elements.privacy.checked;
+      data.formStartedAt=Number(data.formStartedAt);
+      try{
+        const response=await fetch('/api/submit',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});
+        const result=await response.json();
+        if(!response.ok)throw new Error(result.message||'Übermittlung fehlgeschlagen.');
+        target.textContent=result.message;
+        form.reset();
+        form.elements.formStartedAt.value=Date.now();
+        paint();
+      }catch(error){
+        target.textContent=error.message||'Die Übermittlung ist fehlgeschlagen. Bitte versuchen Sie es später erneut.';
+      }finally{button.disabled=false}
+    });
+  }
+  all('[data-event-select]').forEach(e=>e.addEventListener('change',()=>{active=events.find(x=>x.id===e.value)||events[0];paint()}));
+  all('form[data-submit-form]').forEach(initializeForm);
+  paint();
+  const section=params.get('section')||location.hash.slice(1);
+  if(section)requestAnimationFrame(()=>document.getElementById(section)?.scrollIntoView());
+})();

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -25,3 +25,5 @@
 .provider-logo img{display:block;width:100%;height:auto}
 @media(max-width:760px){.legal-grid{grid-template-columns:1fr}.legal-card-wide{grid-column:auto}}
 @media(max-width:380px){.legal-grid{width:min(1120px,calc(100% - 22px))}}
+.honeypot{position:absolute!important;left:-10000px!important;width:1px!important;height:1px!important;overflow:hidden!important}
+button[disabled]{cursor:wait;opacity:.7}

--- a/public/teilnahme.html
+++ b/public/teilnahme.html
@@ -21,12 +21,12 @@
 <a href="/veranstaltung-hamm.html">Veranstaltung</a>
 </nav>
 </header>
-<div class="preview-bar">Veröffentlichungsvorbereitung · Online-Beiträge und Kontaktformulare sind noch nicht aktiv</div>
+<div class="preview-bar">Öffentliche Informations- und Beteiligungsseite · Übermittlung verschlüsselt</div>
 <main id="main" class="module-page">
 <section class="module-hero">
 <p class="eyebrow">Öffentliche Beteiligung · Information</p>
 <h1>Wozu möchten Sie sich beteiligen?</h1>
-<p class="lead">Informieren Sie sich über allgemeine Beteiligungsmöglichkeiten oder eine freigegebene Veranstaltung. Die Online-Übermittlung von Beiträgen und Kontakten wird noch vorbereitet.</p>
+<p class="lead">Informieren Sie sich über allgemeine Beteiligungsmöglichkeiten oder eine freigegebene Veranstaltung. Fachliche Beiträge und freiwillige Kontaktanfragen werden getrennt übermittelt.</p>
 </section>
 <section id="auswahl" aria-labelledby="auswahl-title">
 <h2 id="auswahl-title">Bezug auswählen</h2>
@@ -72,9 +72,12 @@
 <section id="beitrag" class="section" aria-labelledby="beitrag-title">
 <p class="section-label">Getrennter Datenweg 1</p>
 <h2 id="beitrag-title">Fachlicher Beitrag</h2>
-<p class="notice"><strong>Noch nicht aktiv:</strong> Die Online-Übermittlung fachlicher Beiträge wird datenschutzkonform vorbereitet. Später sollen Beiträge ohne Pflicht zur Angabe von Name, E-Mail oder Telefonnummer möglich sein.</p>
-<form data-preview-form novalidate hidden aria-hidden="true">
+<p class="notice"><strong>Ohne Kontaktdaten möglich:</strong> Der fachliche Beitrag wird getrennt von Kontaktanfragen übermittelt. Name, E-Mail und Telefonnummer werden hier nicht verlangt.</p>
+<form data-submit-form="contribution" novalidate>
+<input type="hidden" name="formType" value="contribution">
 <input type="hidden" name="eventContext">
+<input type="hidden" name="formStartedAt">
+<label class="honeypot" aria-hidden="true">Website<input name="website" tabindex="-1" autocomplete="off"></label>
 <div class="context-panel">
 <strong>Gewählter Bezug:</strong> <span data-context-label>
 </span>
@@ -108,7 +111,8 @@
 </div>
 </fieldset>
 <p>Der Beitrag wird nicht automatisch bewertet und bedeutet keine fachliche Zustimmung oder Freigabe.</p>
-<button type="submit">Preview der Übermittlung prüfen</button>
+<label class="check"><input type="checkbox" name="privacy" required> Ich habe die <a href="/datenschutz.html">Datenschutzerklärung</a> gelesen. *</label>
+<button type="submit">Fachlichen Beitrag senden</button>
 <div class="preview-result" data-preview-result role="status" tabindex="-1" hidden>
 </div>
 </form>
@@ -117,9 +121,12 @@
 <section id="kontakt" class="section" aria-labelledby="kontakt-title">
 <p class="section-label">Getrennter Datenweg 2</p>
 <h2 id="kontakt-title">Freiwillig Kontakt aufnehmen</h2>
-<p class="notice"><strong>Noch nicht aktiv:</strong> Der Online-Kontaktweg wird getrennt vom fachlichen Beitrag vorbereitet. Derzeit werden über diese Website keine Kontaktangaben entgegengenommen.</p>
-<form data-preview-form novalidate hidden aria-hidden="true">
+<p class="notice"><strong>Freiwilliger Kontaktweg:</strong> Diese Angaben werden getrennt von fachlichen Beiträgen übermittelt und nur zur Bearbeitung Ihrer Kontaktanfrage verwendet.</p>
+<form data-submit-form="contact" novalidate>
+<input type="hidden" name="formType" value="contact">
 <input type="hidden" name="eventContext">
+<input type="hidden" name="formStartedAt">
+<label class="honeypot" aria-hidden="true">Website<input name="website" tabindex="-1" autocomplete="off"></label>
 <div class="context-panel">
 <strong>Gewählter Bezug:</strong> <span data-context-label>
 </span>
@@ -194,8 +201,8 @@
 <textarea id="nachricht" name="message" rows="4">
 </textarea>
 <label class="check">
-<input type="checkbox" name="privacy" required> Ich habe den Preview- und Datenschutzhinweis gelesen. *</label>
-<button type="submit">Preview der Übermittlung prüfen</button>
+<input type="checkbox" name="privacy" required> Ich habe die <a href="/datenschutz.html">Datenschutzerklärung</a> gelesen. *</label>
+<button type="submit">Kontaktanfrage senden</button>
 <div class="preview-result" data-preview-result role="status" tabindex="-1" hidden>
 </div>
 </form>
@@ -287,7 +294,7 @@
 <p>
 <a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a>
 </p>
-<p>ZukunftsCheck · Informationsangebot · Online-Formulare noch nicht aktiv</p>
+<p>ZukunftsCheck · Informations- und Beteiligungsangebot</p>
 </footer>
 <script src="/events.js">
 </script>

--- a/tests/preview-check.mjs
+++ b/tests/preview-check.mjs
@@ -25,11 +25,14 @@ for(const phrase of ['mucmib@googlemail.com','Vercel Inc.','Standardvertragsklau
 for(const forbidden of ['Brevo','Pure Energien','Solarstromkampagne']) assert.ok(!privacy.includes(forbidden),`Fremder Kampagnenbezug gefunden: ${forbidden}`);
 for(const forbidden of ['localStorage','sessionStorage','XMLHttpRequest','sendBeacon','WebSocket','type="file"','Interne Testprüfung','Gesamtsicherung','Synthetische Demodaten']) assert.ok(!all.includes(forbidden),`Verbotener Bestandteil gefunden: ${forbidden}`);
 assert.ok(!/<form[^>]+action=/i.test(part),'Formularziel darf nicht gesetzt sein');
-assert.equal((part.match(/data-preview-form/g)||[]).length,2,'Beitrag und Kontakt müssen getrennte Formulare sein');
-assert.equal((part.match(/<form data-preview-form novalidate hidden aria-hidden="true">/g)||[]).length,2,'Beide Formulare müssen bis Formularfreigabe B ausgeblendet sein');
-assert.match(part,/Online-Beiträge und Kontaktformulare sind noch nicht aktiv/,'Öffentlicher Sperrhinweis fehlt');
+assert.equal((part.match(/data-submit-form=/g)||[]).length,2,'Beitrag und Kontakt müssen getrennte Formulare sein');
+assert.equal((part.match(/name="formStartedAt"/g)||[]).length,2,'Zeitbasierter Spamschutz fehlt');
+assert.equal((part.match(/class="honeypot"/g)||[]).length,2,'Honeypot-Spamschutz fehlt');
+assert.doesNotMatch(part,/<form[^>]+hidden/i,'Aktive Formulare dürfen nicht ausgeblendet sein');
 assert.match(js,/preventDefault\(\)/,'Absenden wird nicht abgefangen');
-assert.match(js,/übermittelt und speichert derzeit keine Daten/,'Preview-Hinweis fehlt');
+assert.match(js,/fetch\('\/api\/submit'/,'Serverseitiger Formularweg fehlt');
+assert.match(privacy,/Getrennte Formularwege/,'Datenschutzhinweis zu Formularen fehlt');
+assert.match(privacy,/Gmail/,'Hinweis zum E-Mail-Dienst fehlt');
 assert.match(css,/:focus-visible/,'sichtbarer Fokus fehlt');
 assert.equal((part.match(/class="stage-facts"/g)||[]).length,4,'Alle vier Stufen brauchen vertiefende Informationen');
 for(const phrase of ['Das Ergebnis','Die Grenze']) assert.equal((part.match(new RegExp(phrase,'g'))||[]).length,4,`Stufeninformation fehlt: ${phrase}`);
@@ -39,4 +42,8 @@ for(const href of [...all.matchAll(/(?:href|src)="\/(?!\/)([^"?#]+)/g)].map(m=>m
 for(const forbidden of ['ZS-MUSTER-001','ZS-MUSTER-002','Alpenstadt']) assert.ok(!all.includes(forbidden),`Gesperrtes synthetisches Muster gefunden: ${forbidden}`);
 const vercel=fs.readFileSync(path.resolve('vercel.json'),'utf8');
 for(const header of ['Content-Security-Policy','Permissions-Policy','X-Frame-Options','X-Content-Type-Options','Referrer-Policy']) assert.ok(vercel.includes(header),`Sicherheitsheader fehlt: ${header}`);
-console.log('ZS-WEB-022 Preview-Prüfung bestanden.');
+assert.ok(fs.existsSync(path.resolve('api/submit.js')),'Formular-Endpunkt fehlt');
+const api=fs.readFileSync(path.resolve('api/submit.js'),'utf8');
+for(const phrase of ['GMAIL_USER','GMAIL_APP_PASSWORD','MAIL_TO','smtp.gmail.com','nodemailer']) assert.ok(api.includes(phrase),`Mailkonfiguration fehlt: ${phrase}`);
+for(const secret of ['mucmib@googlemail.com']) assert.ok(!api.includes(secret),'Empfängeradresse darf nicht im Endpunkt fest codiert sein');
+console.log('ZS-WEB-Formularprüfung bestanden.');

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'"
+          "value": "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'"
         },
         {
           "key": "Permissions-Policy",


### PR DESCRIPTION
## Ziel
Aktiviert die getrennten Formularwege für fachliche Beiträge und freiwillige Kontaktanfragen über eine Vercel-Serverfunktion und Gmail-SMTP.

## Enthalten
- fachlicher Beitrag ohne Pflicht zu Kontaktdaten
- getrennte Kontaktanfrage
- serverseitige Validierung und feste Empfängersteuerung
- Gmail-Zugang ausschließlich über Vercel-Umgebungsvariablen
- Honeypot, Mindestausfüllzeit, Herkunftsprüfung und begrenzte Anfragerate
- keine Website-Datenbank und keine Uploads
- aktualisierte Datenschutzerklärung

## Vor Merge zwingend
- Preview-Deployment erfolgreich
- je eine synthetische Testsendung beider Formulare
- Eingang beider E-Mails bei mucmib@googlemail.com bestätigt

`noindex,nofollow` bleibt bis zur gesonderten Suchmaschinenfreigabe aktiv.