### PR TITLE
Korrektur: veraltete Formularhinweise entfernen

### DIFF
--- a/public/impressum.html
+++ b/public/impressum.html
@@ -18,7 +18,7 @@
       <a href="/index.html">Start</a><a href="/teilnahme.html">Beteiligung</a><a href="/veranstaltung-hamm.html">Veranstaltung</a><a aria-current="page" href="/impressum.html">Impressum</a>
     </nav>
   </header>
-  <div class="preview-bar" role="status">Veröffentlichungsvorbereitung · Online-Formulare sind noch nicht aktiv</div>
+  <div class="preview-bar" role="status">Öffentliche Informations- und Beteiligungsseite · Formulare aktiv</div>
 
   <main id="main" class="legal-main">
     <section class="hero legal-hero" aria-labelledby="hero-title">
@@ -63,14 +63,14 @@
 
     <section class="status-band" aria-labelledby="status-title">
       <h2 id="status-title">Aktueller Status</h2>
-      <p>Veröffentlichungsvorbereitung. Die dargestellten Anbieterangaben wurden am 19. Juli 2026 durch den Diensteanbieter bestätigt. Nicht vorhandene Register- oder Steuerangaben werden nicht ergänzt.</p>
+      <p>Die dargestellten Anbieterangaben wurden am 19. Juli 2026 durch den Diensteanbieter bestätigt. Nicht vorhandene Register- oder Steuerangaben werden nicht ergänzt.</p>
     </section>
   </main>
 
   <footer class="site-footer">
     <p><a href="/">Startseite</a> · <a href="/datenschutz.html">Datenschutz</a> · <a href="/impressum.html" aria-current="page">Impressum</a></p>
     <p>ZukunftsCheck · Informationsangebot</p>
-    <p>Online-Formulare noch nicht aktiv · keine Uploads · kein Tracking</p>
+    <p>Formulare aktiv · keine Uploads · kein Tracking</p>
   </footer>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       <a aria-current="page" href="/index.html">Start</a><a href="#arbeitsweise">Arbeitsweise</a><a href="#grenzen">Grenzen</a><a href="/teilnahme.html">Beteiligung</a>
     </nav>
   </header>
-  <div class="preview-bar" role="status">Veröffentlichungsvorbereitung · Online-Formulare sind noch nicht aktiv</div>
+  <div class="preview-bar" role="status">Öffentliche Informations- und Beteiligungsseite · Formulare aktiv</div>
 
   <main id="main">
     <section class="hero" aria-labelledby="hero-title">
@@ -50,8 +50,8 @@
 
     <section class="section cta" aria-labelledby="cta-title"><div><p class="section-label">Neutraler nächster Schritt</p><h2 id="cta-title">Orientierungsbedarf klären.</h2><p>Ein Erstgespräch kann Anlass, Rolle, Zuständigkeit, Informationsbedarf und den nächsten Schritt einordnen. Dabei werden keine Projektunterlagen gesammelt und keine technische Lösung empfohlen.</p></div><a class="button" href="/teilnahme.html">Beteiligungsmöglichkeiten ansehen</a></section>
 
-    <section class="status-band" aria-labelledby="status-title"><h2 id="status-title">Aktueller Status</h2><p>Die Informationsseiten werden für die Veröffentlichung vorbereitet. Online-Formulare sind noch nicht aktiv. Es gibt keine Uploads, kein Tracking und keine Anbieterstrecke.</p></section>
+    <section class="status-band" aria-labelledby="status-title"><h2 id="status-title">Aktueller Status</h2><p>Die Informationsseiten sind veröffentlicht. Fachliche Beiträge und freiwillige Kontaktanfragen können über getrennte Formulare übermittelt werden. Es gibt keine Uploads, kein Tracking und keine Anbieterstrecke.</p></section>
   </main>
-  <footer class="site-footer"><p><a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a></p><p>ZukunftsCheck · Informationsangebot</p><p>Online-Formulare noch nicht aktiv · keine Uploads · kein Tracking</p></footer>
+  <footer class="site-footer"><p><a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a></p><p>ZukunftsCheck · Informations- und Beteiligungsangebot</p><p>Formulare aktiv · keine Uploads · kein Tracking</p></footer>
 </body>
 </html>

--- a/public/veranstaltung-hamm.html
+++ b/public/veranstaltung-hamm.html
@@ -20,7 +20,7 @@
 <a aria-current="page" href="/veranstaltung-hamm.html">Veranstaltung</a>
 </nav>
 </header>
-<div class="preview-bar">Veröffentlichungsvorbereitung · Online-Anmeldung und Kontaktformulare sind noch nicht aktiv</div>
+<div class="preview-bar">Öffentliche Veranstaltungsinformation · Beteiligungs- und Kontaktformular aktiv</div>
 <main id="main" class="module-page">
 <article class="event-detail">
 <p class="eyebrow">Freigegebene Veranstaltung · Eintritt frei</p>
@@ -60,7 +60,7 @@
 <p>
 <a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a>
 </p>
-<p>ZukunftsCheck · Informationsangebot · Online-Formulare noch nicht aktiv</p>
+<p>ZukunftsCheck · Informations- und Beteiligungsangebot</p>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
Entfernt die nach Aktivierung der Formulare veralteten Hinweise auf Startseite, Veranstaltungsseite und Impressum. Keine Funktionsänderung. Projektprüfung bestanden.