### PR TITLE
Nutzen fachlicher Beiträge klar erläutern

### DIFF
--- a/public/teilnahme.html
+++ b/public/teilnahme.html
@@ -59,7 +59,7 @@
 <section class="path-grid" aria-label="Beteiligungswege">
 <article class="path-card">
 <h2>Fachlicher Beitrag</h2>
-<p>Vorgesehen sind Hinweise, Fragen, Vorschläge und Quellenhinweise – ohne Pflicht zur Angabe von Kontaktdaten.</p>
+<p>Helfen Sie mit Hinweisen, Fragen, Quellen oder praktischen Erfahrungen, blinde Flecken und weiteren Prüfbedarf sichtbar zu machen.</p>
 <a class="button" href="#beitrag">Beteiligungsweg ansehen</a>
 </article>
 <article class="path-card">
@@ -72,6 +72,10 @@
 <section id="beitrag" class="section" aria-labelledby="beitrag-title">
 <p class="section-label">Getrennter Datenweg 1</p>
 <h2 id="beitrag-title">Fachlicher Beitrag</h2>
+<div class="context-panel">
+<p><strong>Ihr Wissen kann helfen, blinde Flecken zu vermeiden.</strong></p>
+<p>Wir sichten Ihren Hinweis und prüfen, ob daraus eine zusätzliche Perspektive, eine Informationslücke oder weiterer Prüfbedarf entsteht. Der Beitrag wird nicht automatisch veröffentlicht, als fachlich bestätigt behandelt oder persönlich beantwortet.</p>
+</div>
 <p class="notice"><strong>Ohne Kontaktdaten möglich:</strong> Der fachliche Beitrag wird getrennt von Kontaktanfragen übermittelt. Name, E-Mail und Telefonnummer werden hier nicht verlangt.</p>
 <form data-submit-form="contribution" novalidate>
 <input type="hidden" name="formType" value="contribution">


### PR DESCRIPTION
Ergänzt auf der Beteiligungsseite, welchen Nutzen fachliche Hinweise haben, wie sie gesichtet werden und welche Zusagen ausdrücklich nicht bestehen. Keine Funktionsänderung. Tests bestanden.