### PR TITLE
Zweck fachlicher Beiträge verständlich erklären

### DIFF
--- a/public/teilnahme.html
+++ b/public/teilnahme.html
@@ -74,7 +74,14 @@
 <h2 id="beitrag-title">Fachlicher Beitrag</h2>
 <div class="context-panel">
 <p><strong>Ihr Wissen kann helfen, blinde Flecken zu vermeiden.</strong></p>
-<p>Wir sichten Ihren Hinweis und prüfen, ob daraus eine zusätzliche Perspektive, eine Informationslücke oder weiterer Prüfbedarf entsteht. Der Beitrag wird nicht automatisch veröffentlicht, als fachlich bestätigt behandelt oder persönlich beantwortet.</p>
+<p>Wenn Sie von einem Thema betroffen sind, praktische Erfahrungen damit haben oder eine wichtige Quelle kennen, können Sie Ihren Hinweis einreichen. Wir ordnen ihn der ausgewählten Veranstaltung beziehungsweise dem genannten Anliegen zu und beziehen ihn in deren Dokumentation und Nachbereitung ein. So können Informationen und Auswirkungen sichtbar werden, die von den Verantwortlichen bislang möglicherweise nicht berücksichtigt wurden.</p>
+<p><strong>Was Sie dabei erwarten können:</strong></p>
+<ul>
+<li>Bei Veranstaltungsbezug fließt der Beitrag in die Dokumentation und Nachbereitung dieser Veranstaltung ein.</li>
+<li>Ein allgemeiner Beitrag unterstützt die Weiterentwicklung des ZukunftsChecks.</li>
+<li>Eine automatische Veröffentlichung oder Umsetzung erfolgt nicht.</li>
+<li>Wenn Sie eine persönliche Rückmeldung wünschen, nutzen Sie bitte zusätzlich das Kontaktformular.</li>
+</ul>
 </div>
 <p class="notice"><strong>Ohne Kontaktdaten möglich:</strong> Der fachliche Beitrag wird getrennt von Kontaktanfragen übermittelt. Name, E-Mail und Telefonnummer werden hier nicht verlangt.</p>
 <form data-submit-form="contribution" novalidate>


### PR DESCRIPTION
Ersetzt die abstrakte Prüfbedarfs-Formulierung durch eine konkrete Erklärung von Zielgruppe, Verwendung und Erwartungen. Keine Funktionsänderung; Tests bestanden.