### PR TITLE
Mobile Überschrift der Rechtseiten korrigieren

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -27,3 +27,4 @@
 @media(max-width:380px){.legal-grid{width:min(1120px,calc(100% - 22px))}}
 .honeypot{position:absolute!important;left:-10000px!important;width:1px!important;height:1px!important;overflow:hidden!important}
 button[disabled]{cursor:wait;opacity:.7}
+@media(max-width:760px){.legal-hero h1{font-size:clamp(1.7rem,7.2vw,2.4rem);overflow-wrap:normal;word-break:normal;hyphens:none}}


### PR DESCRIPTION
Verhindert den unsauberen Wortumbruch der langen Datenschutz-Überschrift auf schmalen Displays. Keine Inhalts- oder Funktionsänderung; Tests bestanden.