### PR TITLE
Öffentliche Entwicklungs- und Statushinweise entfernen

### DIFF
--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -109,10 +109,6 @@
     </section>
     </div>
 
-    <section class="status-band" aria-labelledby="status-title">
-      <h2 id="status-title">Aktueller Status</h2>
-      <p>Informationsseite und getrennte Formularwege sind technisch vorbereitet. Es werden keine Dateien hochgeladen, keine Beiträge öffentlich angezeigt und keine automatische Bewertung oder Weitergabe an Fachpartner vorgenommen.</p>
-    </section>
   </main>
 
   <footer class="site-footer">

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -61,10 +61,6 @@
     </section>
     </div>
 
-    <section class="status-band" aria-labelledby="status-title">
-      <h2 id="status-title">Aktueller Status</h2>
-      <p>Die dargestellten Anbieterangaben wurden am 19. Juli 2026 durch den Diensteanbieter bestätigt. Nicht vorhandene Register- oder Steuerangaben werden nicht ergänzt.</p>
-    </section>
   </main>
 
   <footer class="site-footer">

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,6 @@
 
     <section class="section cta" aria-labelledby="cta-title"><div><p class="section-label">Neutraler nächster Schritt</p><h2 id="cta-title">Orientierungsbedarf klären.</h2><p>Ein Erstgespräch kann Anlass, Rolle, Zuständigkeit, Informationsbedarf und den nächsten Schritt einordnen. Dabei werden keine Projektunterlagen gesammelt und keine technische Lösung empfohlen.</p></div><a class="button" href="/teilnahme.html">Beteiligungsmöglichkeiten ansehen</a></section>
 
-    <section class="status-band" aria-labelledby="status-title"><h2 id="status-title">Aktueller Status</h2><p>Die Informationsseiten sind veröffentlicht. Fachliche Beiträge und freiwillige Kontaktanfragen können über getrennte Formulare übermittelt werden. Es gibt keine Uploads, kein Tracking und keine Anbieterstrecke.</p></section>
   </main>
   <footer class="site-footer"><p><a href="/impressum.html">Impressum</a> · <a href="/datenschutz.html">Datenschutz</a></p><p>ZukunftsCheck · Informations- und Beteiligungsangebot</p><p>Formulare aktiv · keine Uploads · kein Tracking</p></footer>
 </body>

--- a/public/veranstaltung-hamm.html
+++ b/public/veranstaltung-hamm.html
@@ -53,7 +53,6 @@
 <a class="button" href="/teilnahme.html?event=ZS-VA-2027-HAMM-001#beitrag">Beteiligungsmöglichkeiten ansehen</a>
 <a class="button secondary" href="/teilnahme.html?event=ZS-VA-2027-HAMM-001#kontakt">Kontaktinformationen ansehen</a>
 </div>
-<p class="notice">Die Online-Übermittlung von Beiträgen, Anmeldungen und Kontaktdaten ist noch nicht aktiv.</p>
 </article>
 </main>
 <footer class="site-footer">

--- a/tests/preview-check.mjs
+++ b/tests/preview-check.mjs
@@ -17,7 +17,8 @@ const css=read('styles/main.css');
 const all=[index,part,event,js,css].join('\n');
 
 for(const html of [index,part,event]) assert.match(html,/noindex,nofollow/,'robots-Sperre fehlt');
-for(const phrase of ['Neutrale Erstklärung','Was der ZukunftsCheck ist','Räume sind nicht nur Flächen','Was der ZukunftsCheck leistet','Welche Fragen zuerst geklärt werden','Für wen das Format gedacht ist','Wie die Erstklärung abläuft','Räume erfüllen Funktionen','Welche Informationen genügen','Klare Grenzen für saubere Entscheidungen','Mögliche spätere Übergabepunkte','Neutraler nächster Schritt','Aktueller Status']) assert.ok(index.includes(phrase),`Bestandsinhalt fehlt: ${phrase}`);
+for(const phrase of ['Neutrale Erstklärung','Was der ZukunftsCheck ist','Räume sind nicht nur Flächen','Was der ZukunftsCheck leistet','Welche Fragen zuerst geklärt werden','Für wen das Format gedacht ist','Wie die Erstklärung abläuft','Räume erfüllen Funktionen','Welche Informationen genügen','Klare Grenzen für saubere Entscheidungen','Mögliche spätere Übergabepunkte','Neutraler nächster Schritt']) assert.ok(index.includes(phrase),`Bestandsinhalt fehlt: ${phrase}`);
+for(const html of [index,privacy,imprint,event]) assert.doesNotMatch(html,/Aktueller Status|noch nicht aktiv/,'Veralteter öffentlicher Statushinweis gefunden');
 for(const phrase of ['ALLGEMEIN','Leben mit der Energiewende','Fachlicher Beitrag','Freiwillig Kontakt aufnehmen','Stufe 0 – Passungsprüfung','Stufe 1 – Basis-ZukunftsCheck','Stufe 2 – Erweiterter ZukunftsCheck','Stufe 3 – Fachanschluss']) assert.ok(part.includes(phrase),`Teilnahmeinhalt fehlt: ${phrase}`);
 for(const phrase of ['21. Juli 2027','19:00 Uhr','Hochschule Hamm-Lippstadt, Hörsaal HAM 4','Marker Allee 76–78, Hamm','Energiesystem der Zukunft','Electric All-In']) assert.ok(event.includes(phrase),`Veranstaltungsangabe fehlt: ${phrase}`);
 assert.match(imprint,/mib-logo\.png/,'MIB-Logo fehlt im Impressum');


### PR DESCRIPTION
Entfernt die internen Statuskästen auf Startseite, Datenschutz und Impressum sowie den veralteten Hinweis auf der Veranstaltungsseite. Dauerhafte Datenschutz- und Funktionshinweise bleiben erhalten. Tests bestanden.