### PR TITLE
Kopfbereich bereinigen und Wortmarke anpassen

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -6,6 +6,7 @@
   <meta name="robots" content="noindex,nofollow">
   <title>Seite nicht gefunden – ZukunftsCheck</title>
   <link rel="stylesheet" href="/styles/main.css">
+  <link rel="stylesheet" href="/styles/brand.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Zum Hauptinhalt</a>

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -6,6 +6,7 @@
   <meta name="robots" content="noindex,nofollow">
   <title>Datenschutzerklärung – ZukunftsCheck</title>
   <link rel="stylesheet" href="/styles/main.css">
+  <link rel="stylesheet" href="/styles/brand.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Zum Hauptinhalt</a>
@@ -18,7 +19,6 @@
       <a href="/index.html">Start</a><a href="/teilnahme.html">Beteiligung</a><a href="/veranstaltung-hamm.html">Veranstaltung</a><a aria-current="page" href="/datenschutz.html">Datenschutz</a>
     </nav>
   </header>
-  <div class="preview-bar" role="status">Öffentliche Informations- und Beteiligungsseite · Übermittlung verschlüsselt</div>
 
   <main id="main" class="legal-main">
     <section class="hero legal-hero" aria-labelledby="hero-title">

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -6,6 +6,7 @@
   <meta name="robots" content="noindex,nofollow">
   <title>Impressum – ZukunftsCheck</title>
   <link rel="stylesheet" href="/styles/main.css">
+  <link rel="stylesheet" href="/styles/brand.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Zum Hauptinhalt</a>
@@ -18,7 +19,6 @@
       <a href="/index.html">Start</a><a href="/teilnahme.html">Beteiligung</a><a href="/veranstaltung-hamm.html">Veranstaltung</a><a aria-current="page" href="/impressum.html">Impressum</a>
     </nav>
   </header>
-  <div class="preview-bar" role="status">Öffentliche Informations- und Beteiligungsseite · Formulare aktiv</div>
 
   <main id="main" class="legal-main">
     <section class="hero legal-hero" aria-labelledby="hero-title">

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
   <meta name="robots" content="noindex,nofollow">
   <title>ZukunftsCheck – Orientierung vor der Fachplanung</title>
   <link rel="stylesheet" href="/styles/main.css">
+  <link rel="stylesheet" href="/styles/brand.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Zum Hauptinhalt</a>
@@ -15,13 +16,12 @@
       <a aria-current="page" href="/index.html">Start</a><a href="#arbeitsweise">Arbeitsweise</a><a href="#grenzen">Grenzen</a><a href="/teilnahme.html">Beteiligung</a><a href="/veranstaltung-hamm.html">Veranstaltung</a>
     </nav>
   </header>
-  <div class="preview-bar" role="status">Öffentliche Informations- und Beteiligungsseite · Formulare aktiv</div>
 
   <main id="main">
     <section class="hero" aria-labelledby="hero-title">
       <div>
         <p class="eyebrow">Neutrale Erstklärung</p>
-        <h1 id="hero-title">Orientierung, bevor aus offenen Fragen falsche Entscheidungen werden.</h1>
+        <h1 id="hero-title">Orientierung, bevor aus offenen Fragen falsche Entscheidungen werden</h1>
         <p class="lead">Der ZukunftsCheck sammelt keine Projektunterlagen und ersetzt keine Fachplanung. Er klärt zunächst Anlass, Rolle, Zuständigkeit, Informationsbedarf und mögliche nächste Prüfschritte.</p>
         <div class="button-row"><a class="button" href="/teilnahme.html">Beteiligen</a><a class="button secondary" href="#definition">ZukunftsCheck verstehen</a></div>
       </div>

--- a/public/styles/brand.css
+++ b/public/styles/brand.css
@@ -1,0 +1,8 @@
+.brand {
+  font-size: 1.3rem;
+  line-height: 1;
+}
+
+.brand-mark {
+  font-size: 1rem;
+}

--- a/public/teilnahme.html
+++ b/public/teilnahme.html
@@ -6,6 +6,7 @@
 <meta name="robots" content="noindex,nofollow">
 <title>Beteiligung – ZukunftsCheck</title>
 <link rel="stylesheet" href="/styles/main.css">
+<link rel="stylesheet" href="/styles/brand.css">
 </head>
 <body>
 <a class="skip-link" href="#main">Zum Hauptinhalt</a>
@@ -21,7 +22,6 @@
 <a href="/veranstaltung-hamm.html">Veranstaltung</a>
 </nav>
 </header>
-<div class="preview-bar">Öffentliche Informations- und Beteiligungsseite · Übermittlung verschlüsselt</div>
 <main id="main" class="module-page">
 <section class="module-hero">
 <p class="eyebrow">Öffentliche Beteiligung · Information</p>

--- a/public/veranstaltung-hamm.html
+++ b/public/veranstaltung-hamm.html
@@ -6,6 +6,7 @@
 <meta name="robots" content="noindex,nofollow">
 <title>Leben mit der Energiewende – ZukunftsCheck</title>
 <link rel="stylesheet" href="/styles/main.css">
+<link rel="stylesheet" href="/styles/brand.css">
 </head>
 <body>
 <a class="skip-link" href="#main">Zum Hauptinhalt</a>
@@ -20,7 +21,6 @@
 <a aria-current="page" href="/veranstaltung-hamm.html">Veranstaltung</a>
 </nav>
 </header>
-<div class="preview-bar">Öffentliche Veranstaltungsinformation · Beteiligungs- und Kontaktformular aktiv</div>
 <main id="main" class="module-page">
 <article class="event-detail">
 <p class="eyebrow">Freigegebene Veranstaltung · Eintritt frei</p>


### PR DESCRIPTION
Entfernt die öffentlichen Statusbalken, entfernt den Schlusspunkt in der Startseitenüberschrift und vergrößert die Wortmarke ZukunftsCheck passend zum ZC-Logo.

Prüfung: npm test erfolgreich.