### PR TITLE
Aktuelle Beteiligungsfrage aus main übernehmen

### DIFF
--- a/public/teilnahme.html
+++ b/public/teilnahme.html
@@ -25,7 +25,7 @@
 <main id="main" class="module-page">
 <section class="module-hero">
 <p class="eyebrow">Öffentliche Beteiligung · Information</p>
-<h1>Wozu möchten Sie sich beteiligen?</h1>
+<h1>Worauf bezieht sich Ihr Beitrag?</h1>
 <p class="lead">Informieren Sie sich über allgemeine Beteiligungsmöglichkeiten oder eine freigegebene Veranstaltung. Fachliche Beiträge und freiwillige Kontaktanfragen werden getrennt übermittelt.</p>
 </section>
 <section id="auswahl" aria-labelledby="auswahl-title">


### PR DESCRIPTION
Übernimmt die zwischenzeitliche Änderung aus `main` in den Arbeitsbranch `feature/angebotsunterseiten-v0-1`.

Geändert wird ausschließlich die Überschrift auf der Beteiligungsseite:

- bisher: „Wozu möchten Sie sich beteiligen?“
- neu: „Worauf bezieht sich Ihr Beitrag?“

Die sechs Angebots- und Projektsteuerungsseiten bleiben unverändert. Kein Merge nach `main`, keine Produktivschaltung.