### PR TITLE
Fix German heading hyphenation

### DIFF
--- a/public/styles/brand.css
+++ b/public/styles/brand.css
@@ -32,3 +32,24 @@
     text-align: center;
   }
 }
+
+/* German heading hyphenation: avoid arbitrary mid-word breaks while retaining safe wrapping. */
+h1,
+h2,
+h3 {
+  overflow-wrap: normal;
+  word-break: normal;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+
+@media (max-width: 380px) {
+  h1,
+  h2,
+  h3 {
+    overflow-wrap: normal;
+    word-break: normal;
+    -webkit-hyphens: auto;
+    hyphens: auto;
+  }
+}


### PR DESCRIPTION
Korrigiert die globale Überschriften-Trennlogik für deutsche Inhalte. Verhindert willkürliche Wortumbrüche durch `overflow-wrap: break-word/anywhere` und aktiviert sprachabhängige Silbentrennung für h1–h3. Die bestehende Gestaltung und Textinhalte bleiben unverändert.