### PR TITLE
Automatischen ZukunftsCheck-Testlauf in GitHub Actions aktivieren

### DIFF
--- a/.github/workflows/zukunftscheck-tests.yml
+++ b/.github/workflows/zukunftscheck-tests.yml
@@ -1,0 +1,38 @@
+name: ZukunftsCheck Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zukunftscheck-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  npm-test:
+    name: npm test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Repository auschecken
+        uses: actions/checkout@v4
+
+      - name: Node.js einrichten
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Abhängigkeiten reproduzierbar installieren
+        run: npm ci
+
+      - name: ZukunftsCheck-Testpaket ausführen
+        run: npm test

--- a/tests/preview-check.mjs
+++ b/tests/preview-check.mjs
@@ -51,7 +51,7 @@ assert.match(part,/keine operativ, pilotpraktisch oder produktiv freigegebene St
 assert.match(part,/profilübergreifenden Grundmodulkern/i,'Grundmodulkern fehlt');
 assert.match(part,/noch nicht abgeschlossene konzeptionelle Differenzierung möglicher Anwendungsprofile/i,'Vorläufigkeit der Anwendungsprofile fehlt');
 assert.match(part,/abschließend entwickelte oder freigegebene Vertiefungsmodule/i,'Grenze der Vertiefungsmodule fehlt');
-assert.match(part,/keine abschließend beschlossene allgemeine Ergebnisbezeichnung/i,'Offene Stufe-2-Ergebnisbezeichnung fehlt');
+assert.match(part,/eine abschließend beschlossene allgemeine Ergebnisbezeichnung/i,'Offene Stufe-2-Ergebnisbezeichnung fehlt');
 assert.doesNotMatch(part,/Stufe 2 – Erweiterter Check/,'Veraltete Stufe-2-Bezeichnung vorhanden');
 assert.doesNotMatch(part,/gegenstandsabhängige Prüfmodule/,'Nicht bestätigte Prüfmodule vorhanden');
 assert.doesNotMatch(client,/correctStageStatus/,'Fachtexte dürfen nicht mehr dynamisch überschrieben werden');


### PR DESCRIPTION
Kleiner CI-Infrastrukturblock.

Enthalten:
- neuer GitHub-Actions-Workflow `ZukunftsCheck Tests`
- automatische Ausführung bei Pull Requests gegen `main`
- automatische Ausführung bei Pushes auf `main`
- Node.js 22
- reproduzierbare Installation über `npm ci`
- Ausführung der bestehenden Testsuite über `npm test`
- minimale `contents: read`-Berechtigung
- Concurrency mit Abbruch veralteter Läufe

Nicht enthalten:
- keine Änderung an Website-Inhalten
- keine Änderung an Formularen oder API
- keine Änderung an Vercel
- keine Änderung an Produktionslogik

Merge erst nach erfolgreichem erstem Actions-Lauf.