### PR TITLE
Kartenlinks in Boxen zentrieren

### DIFF
--- a/public/scripts/mobile-navigation.js
+++ b/public/scripts/mobile-navigation.js
@@ -75,6 +75,15 @@
     }
   }
 
+  const definitionTitle = document.querySelector('#definition-title');
+  if (definitionTitle && !definitionTitle.querySelector('.desktop-definition-break')) {
+    definitionTitle.replaceChildren(
+      document.createTextNode('Orientierung, Strukturierung und Klärung'),
+      Object.assign(document.createElement('br'), { className: 'desktop-definition-break' }),
+      document.createTextNode('des nächsten belastbaren Schritts.')
+    );
+  }
+
   /* Globale Navigation: auf allen Inhaltsseiten dieselben fünf Hauptziele. */
   const currentPath = window.location.pathname;
   const navItems = [

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -49,9 +49,12 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
 .events-upcoming .card:nth-child(2){background:var(--ui-card-blue)!important}
 
 /* Nur die Aktionslinks innerhalb von Boxen werden mittig gesetzt.
-   Der Linkbereich spannt die Kartenbreite auf, damit auch mehrzeilige Links sauber zentriert sind.
-   Überschriften und Fließtext bleiben bewusst linksbündig. */
-.card .text-link,
+   Diese Selektoren sind bewusst mindestens so spezifisch wie die ältere
+   Linksbuendig-Regel in ui-consistency.css, damit die spaeter geladene
+   Farbbalance-Schicht die Linkausrichtung verlaesslich uebernimmt.
+   Ueberschriften und Fliesstext bleiben linksbuendig. */
+.cards.three>.card .text-link,
+#angebote .applications-grid>.card .text-link,
 .path-card .text-link,
 .stage-card .text-link,
 .event-card .text-link{

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -85,4 +85,5 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
 
 @media(max-width:760px){
   #angebote .applications-grid>.project-control-card{padding-top:4.4rem!important}
+  #definition-title .desktop-definition-break{display:none}
 }

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -49,12 +49,14 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
 .events-upcoming .card:nth-child(2){background:var(--ui-card-blue)!important}
 
 /* Nur die Aktionslinks innerhalb von Boxen werden mittig gesetzt.
+   Der Linkbereich spannt die Kartenbreite auf, damit auch mehrzeilige Links sauber zentriert sind.
    Überschriften und Fließtext bleiben bewusst linksbündig. */
 .card .text-link,
 .path-card .text-link,
 .stage-card .text-link,
 .event-card .text-link{
-  align-self:center!important;
+  width:100%!important;
+  align-self:stretch!important;
   text-align:center!important;
 }
 

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -48,18 +48,38 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
 .events-upcoming .card:nth-child(1){background:var(--ui-card-neutral)!important}
 .events-upcoming .card:nth-child(2){background:var(--ui-card-blue)!important}
 
-/* Nur die Aktionslinks innerhalb von Boxen werden mittig gesetzt.
-   Diese Selektoren sind bewusst mindestens so spezifisch wie die ältere
-   Linksbuendig-Regel in ui-consistency.css, damit die spaeter geladene
-   Farbbalance-Schicht die Linkausrichtung verlaesslich uebernimmt.
+/* Einheitliche Aktionsausrichtung in allen Boxen.
+   Textlinks spannen die Kartenbreite auf und werden auch bei Zeilenumbruch sauber zentriert.
+   Als Button gestaltete Links bleiben kompakt, sitzen aber mittig.
    Ueberschriften und Fliesstext bleiben linksbuendig. */
 .cards.three>.card .text-link,
 #angebote .applications-grid>.card .text-link,
-.path-card .text-link,
-.stage-card .text-link,
-.event-card .text-link{
+.card>.text-link,
+.hero-card>.text-link,
+.path-card>.text-link,
+.stage-card>.text-link,
+.event-card>.text-link,
+.legal-card>.text-link,
+.event-card>a:not(.button):not(.secondary){
+  display:block!important;
   width:100%!important;
   align-self:stretch!important;
+  margin-left:auto!important;
+  margin-right:auto!important;
+  text-align:center!important;
+}
+
+.cards.three>.card>.button,
+#angebote .applications-grid>.card>.button,
+.card>.button,
+.hero-card>.button,
+.path-card>.button,
+.stage-card>.button,
+.event-card>.button,
+.legal-card>.button{
+  align-self:center!important;
+  margin-left:auto!important;
+  margin-right:auto!important;
   text-align:center!important;
 }
 

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -48,6 +48,16 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
 .events-upcoming .card:nth-child(1){background:var(--ui-card-neutral)!important}
 .events-upcoming .card:nth-child(2){background:var(--ui-card-blue)!important}
 
+/* Nur die Aktionslinks innerhalb von Boxen werden mittig gesetzt.
+   Überschriften und Fließtext bleiben bewusst linksbündig. */
+.card .text-link,
+.path-card .text-link,
+.stage-card .text-link,
+.event-card .text-link{
+  align-self:center!important;
+  text-align:center!important;
+}
+
 @media(max-width:760px){
   #angebote .applications-grid>.project-control-card{padding-top:4.4rem!important}
 }

--- a/tests/ui-consistency-check.mjs
+++ b/tests/ui-consistency-check.mjs
@@ -16,6 +16,7 @@ for(const page of pages)assert.ok(fs.existsSync(path.join(root,page)),`${page} f
 
 const nav=read('scripts/mobile-navigation.js');
 const consistency=read('styles/ui-consistency.css');
+const colorBalance=read('styles/ui-color-balance.css');
 const events=read('veranstaltungen.html');
 const participation=read('participation.js');
 
@@ -32,6 +33,11 @@ assert.match(consistency,/\.event-detail\{/,'Event-Detailseiten haben keine geme
 assert.match(consistency,/\.event-facts\{/,'Event-Faktenraster ist nicht zentral normalisiert');
 assert.match(consistency,/\.cards\.three>\.card/,'Normale Drei-Karten-Raster werden nicht zentral kontrolliert');
 assert.match(consistency,/text-align:left!important/,'Normale Inhaltskarten werden nicht linksbündig zurückgesetzt');
+
+assert.match(colorBalance,/\.card \.text-link/,'Zentrierregel für Kartenlinks fehlt');
+assert.match(colorBalance,/width:100%!important/,'Mehrzeilige Kartenlinks spannen nicht die Kartenbreite auf');
+assert.match(colorBalance,/align-self:stretch!important/,'Kartenlinks werden nicht über die verfügbare Breite gestreckt');
+assert.match(colorBalance,/text-align:center!important/,'Kartenlinks werden nicht mittig ausgerichtet');
 
 assert.match(events,/class="cards events-upcoming"/,'Kommende Veranstaltungen nutzen kein eigenes Raster');
 assert.equal((events.match(/class="badge event-badge"/g)||[]).length,2,'Die zwei Oktobertermine brauchen zweizeilige Termin-Badges');

--- a/tests/ui-consistency-check.mjs
+++ b/tests/ui-consistency-check.mjs
@@ -34,10 +34,27 @@ assert.match(consistency,/\.event-facts\{/,'Event-Faktenraster ist nicht zentral
 assert.match(consistency,/\.cards\.three>\.card/,'Normale Drei-Karten-Raster werden nicht zentral kontrolliert');
 assert.match(consistency,/text-align:left!important/,'Normale Inhaltskarten werden nicht linksbündig zurückgesetzt');
 
-assert.match(colorBalance,/\.card \.text-link/,'Zentrierregel für Kartenlinks fehlt');
+for(const selector of [
+  '.cards.three>.card .text-link',
+  '#angebote .applications-grid>.card .text-link',
+  '.card>.text-link',
+  '.hero-card>.text-link',
+  '.path-card>.text-link',
+  '.stage-card>.text-link',
+  '.event-card>.text-link',
+  '.legal-card>.text-link',
+  '.event-card>a:not(.button):not(.secondary)',
+  '.card>.button',
+  '.hero-card>.button',
+  '.path-card>.button',
+  '.stage-card>.button',
+  '.event-card>.button',
+  '.legal-card>.button'
+]) assert.ok(colorBalance.includes(selector),`Globale Kartenaktionsregel fehlt: ${selector}`);
 assert.match(colorBalance,/width:100%!important/,'Mehrzeilige Kartenlinks spannen nicht die Kartenbreite auf');
-assert.match(colorBalance,/align-self:stretch!important/,'Kartenlinks werden nicht über die verfügbare Breite gestreckt');
-assert.match(colorBalance,/text-align:center!important/,'Kartenlinks werden nicht mittig ausgerichtet');
+assert.match(colorBalance,/align-self:stretch!important/,'Textlinks werden nicht über die verfügbare Breite gestreckt');
+assert.match(colorBalance,/align-self:center!important/,'Button-Links werden nicht als Element zentriert');
+assert.match(colorBalance,/text-align:center!important/,'Kartenaktionen werden nicht mittig ausgerichtet');
 
 assert.match(events,/class="cards events-upcoming"/,'Kommende Veranstaltungen nutzen kein eigenes Raster');
 assert.equal((events.match(/class="badge event-badge"/g)||[]).length,2,'Die zwei Oktobertermine brauchen zweizeilige Termin-Badges');


### PR DESCRIPTION
Kleine visuelle Korrektur.

Enthalten:
- nur Aktionslinks innerhalb der Karten werden horizontal zentriert
- Überschriften und Fließtext bleiben linksbündig
- keine Inhalts-, Formular-, API- oder Methodikänderung

Merge erst nach erfolgreicher CI- und Preview-Prüfung.