### PR TITLE
Desktop-Umbrüche auf der Hauptseite ergänzen

### DIFF
--- a/public/scripts/mobile-navigation.js
+++ b/public/scripts/mobile-navigation.js
@@ -84,6 +84,24 @@
     );
   }
 
+  const stagesTitle = document.querySelector('#stages-title');
+  if (stagesTitle && !stagesTitle.querySelector('.desktop-stages-break')) {
+    stagesTitle.replaceChildren(
+      document.createTextNode('Von der kostenfreien ersten Einordnung'),
+      Object.assign(document.createElement('br'), { className: 'desktop-stages-break' }),
+      document.createTextNode('zum passenden nächsten Schritt.')
+    );
+  }
+
+  const limitsTitle = document.querySelector('#limits-title');
+  if (limitsTitle && !limitsTitle.querySelector('.desktop-limits-break')) {
+    limitsTitle.replaceChildren(
+      document.createTextNode('Der ZukunftsCheck bleibt vor Fachplanung,'),
+      Object.assign(document.createElement('br'), { className: 'desktop-limits-break' }),
+      document.createTextNode('Umsetzung und spezialisierten Beratungsleistungen.')
+    );
+  }
+
   /* Globale Navigation: auf allen Inhaltsseiten dieselben fünf Hauptziele. */
   const currentPath = window.location.pathname;
   const navItems = [

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -85,5 +85,7 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
 
 @media(max-width:760px){
   #angebote .applications-grid>.project-control-card{padding-top:4.4rem!important}
-  #definition-title .desktop-definition-break{display:none}
+  #definition-title .desktop-definition-break,
+  #stages-title .desktop-stages-break,
+  #limits-title .desktop-limits-break{display:none}
 }


### PR DESCRIPTION
Gezielte typografische Feinkorrektur auf der Hauptseite.

Enthalten:
- Desktop-Zeilenumbruch nach „Einordnung“ im Abschnitt „Der Ablauf“
- Desktop-Zeilenumbruch nach „Fachplanung,“ im Abschnitt „Klare Grenzen“
- bestehender Desktop-Umbruch nach „Klärung“ bleibt unverändert
- mobile Darstellung bleibt flexibel; die festen Umbrüche werden dort ausgeblendet
- keine Inhalts-, Formular-, API- oder Methodikänderung

Merge erst nach CI- und Preview-Prüfung.