### PR TITLE
Formulare mit Turnstile gegen Bot-Spam härten

### DIFF
--- a/api/submit.js
+++ b/api/submit.js
@@ -1,5 +1,6 @@
 const nodemailer = require('nodemailer');
 
+const TEST_TURNSTILE_SECRET='1x0000000000000000000000000000000AA';
 const LIMITS = {
   text:10000, topic:300, source:500, location:300, perspective:1000,
   name:200, email:320, phone:100, organization:300, organizationType:200,
@@ -7,7 +8,7 @@ const LIMITS = {
   projectTitle:200, projectType:200, projectDescription:3000,
   pendingDecision:2000, requesterRole:500, involvedParties:2000,
   existingChecks:3000, openQuestion:2000, projectStage:200,
-  timeframe:300, additionalContext:2000
+  timeframe:300, additionalContext:2000, turnstileToken:2048
 };
 
 const clean = (value, key) => String(value ?? '')
@@ -32,10 +33,53 @@ const attempts = new Map();
 function allowedOrigin(origin) {
   try {
     const host = new URL(origin).hostname;
-    return host === 'zukunftscheck.org' || host === 'www.zukunftscheck.org' || host.endsWith('.vercel.app');
+    if (host === 'zukunftscheck.org' || host === 'www.zukunftscheck.org') return true;
+    if (host === 'zukunftscheck-web.vercel.app') return true;
+    return host.startsWith('zukunftscheck-') && host.endsWith('-hans-leo-baders-projects.vercel.app');
   } catch {
     return false;
   }
+}
+
+function isProduction(){
+  return String(process.env.VERCEL_ENV||process.env.NODE_ENV||'development').toLowerCase()==='production';
+}
+
+async function verifyTurnstile(token,client){
+  const production=isProduction();
+  const secret=production?process.env.TURNSTILE_SECRET_KEY:(process.env.TURNSTILE_SECRET_KEY||TEST_TURNSTILE_SECRET);
+  if(!secret)return {configured:false,success:false};
+
+  const payload=new URLSearchParams();
+  payload.set('secret',secret);
+  payload.set('response',token);
+  if(client&&client!=='unknown')payload.set('remoteip',client);
+
+  try{
+    const response=await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify',{
+      method:'POST',
+      headers:{'Content-Type':'application/x-www-form-urlencoded'},
+      body:payload.toString()
+    });
+    if(!response.ok)return {configured:true,success:false};
+    const result=await response.json();
+    if(!result.success)return {configured:true,success:false};
+    if(production&&!['zukunftscheck.org','www.zukunftscheck.org'].includes(result.hostname)){
+      return {configured:true,success:false};
+    }
+    return {configured:true,success:true};
+  }catch{
+    return {configured:true,success:false};
+  }
+}
+
+function exceedsRateLimit(client,now){
+  const recentDay=(attempts.get(client)||[]).filter(time=>now-time<86400000);
+  const recentTenMinutes=recentDay.filter(time=>now-time<600000);
+  if(recentTenMinutes.length>=5||recentDay.length>=20)return true;
+  recentDay.push(now);
+  attempts.set(client,recentDay);
+  return false;
 }
 
 module.exports = async function handler(req, res) {
@@ -44,18 +88,30 @@ module.exports = async function handler(req, res) {
   if (!req.headers['content-type']?.includes('application/json')) return res.status(415).json({ok:false,message:'Ungültiges Datenformat.'});
   if (!allowedOrigin(req.headers.origin)) return res.status(403).json({ok:false,message:'Anfrage nicht zulässig.'});
 
-  const client = String(req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown').split(',')[0].trim();
-  const now = Date.now();
-  const recent = (attempts.get(client) || []).filter(time => now-time < 600000);
-  if (recent.length >= 5) return res.status(429).json({ok:false,message:'Zu viele Anfragen. Bitte versuchen Sie es später erneut.'});
-  recent.push(now);
-  attempts.set(client,recent);
-
   const body = req.body || {};
   if (body.website) return res.status(200).json({ok:true,message:'Vielen Dank.'});
+
   const started = Number(body.formStartedAt);
   if (!Number.isFinite(started) || Date.now()-started < 2000 || Date.now()-started > 86400000) {
     return res.status(400).json({ok:false,message:'Bitte laden Sie die Seite neu und versuchen Sie es erneut.'});
+  }
+
+  const client = String(req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown').split(',')[0].trim();
+  const turnstileToken=clean(body.turnstileToken,'turnstileToken');
+  if(!turnstileToken){
+    return res.status(400).json({ok:false,message:'Bitte schließen Sie die Sicherheitsprüfung gegen automatisierte Anfragen ab.'});
+  }
+  const turnstile=await verifyTurnstile(turnstileToken,client);
+  if(!turnstile.configured){
+    return res.status(503).json({ok:false,message:'Die Sicherheitsprüfung ist derzeit nicht verfügbar.'});
+  }
+  if(!turnstile.success){
+    return res.status(403).json({ok:false,message:'Die Sicherheitsprüfung war nicht erfolgreich. Bitte versuchen Sie es erneut.'});
+  }
+
+  const now=Date.now();
+  if(exceedsRateLimit(client,now)){
+    return res.status(429).json({ok:false,message:'Zu viele Anfragen. Bitte versuchen Sie es später erneut.'});
   }
 
   const formType = ['contribution','stage0','contact'].includes(body.formType) ? body.formType : '';

--- a/api/submit.js
+++ b/api/submit.js
@@ -45,6 +45,10 @@ function isProduction(){
   return String(process.env.VERCEL_ENV||process.env.NODE_ENV||'development').toLowerCase()==='production';
 }
 
+function turnstileRequired(){
+  return Boolean(process.env.VERCEL_ENV)||isProduction();
+}
+
 async function verifyTurnstile(token,client){
   const production=isProduction();
   const secret=production?process.env.TURNSTILE_SECRET_KEY:(process.env.TURNSTILE_SECRET_KEY||TEST_TURNSTILE_SECRET);
@@ -97,16 +101,18 @@ module.exports = async function handler(req, res) {
   }
 
   const client = String(req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown').split(',')[0].trim();
-  const turnstileToken=clean(body.turnstileToken,'turnstileToken');
-  if(!turnstileToken){
-    return res.status(400).json({ok:false,message:'Bitte schließen Sie die Sicherheitsprüfung gegen automatisierte Anfragen ab.'});
-  }
-  const turnstile=await verifyTurnstile(turnstileToken,client);
-  if(!turnstile.configured){
-    return res.status(503).json({ok:false,message:'Die Sicherheitsprüfung ist derzeit nicht verfügbar.'});
-  }
-  if(!turnstile.success){
-    return res.status(403).json({ok:false,message:'Die Sicherheitsprüfung war nicht erfolgreich. Bitte versuchen Sie es erneut.'});
+  if(turnstileRequired()){
+    const turnstileToken=clean(body.turnstileToken,'turnstileToken');
+    if(!turnstileToken){
+      return res.status(400).json({ok:false,message:'Bitte schließen Sie die Sicherheitsprüfung gegen automatisierte Anfragen ab.'});
+    }
+    const turnstile=await verifyTurnstile(turnstileToken,client);
+    if(!turnstile.configured){
+      return res.status(503).json({ok:false,message:'Die Sicherheitsprüfung ist derzeit nicht verfügbar.'});
+    }
+    if(!turnstile.success){
+      return res.status(403).json({ok:false,message:'Die Sicherheitsprüfung war nicht erfolgreich. Bitte versuchen Sie es erneut.'});
+    }
   }
 
   const now=Date.now();

--- a/api/turnstile-config.js
+++ b/api/turnstile-config.js
@@ -1,0 +1,16 @@
+const TEST_SITE_KEY='1x00000000000000000000AA';
+
+module.exports=function handler(req,res){
+  res.setHeader('Cache-Control','no-store');
+  if(req.method!=='GET')return res.status(405).json({ok:false,message:'Methode nicht zulässig.'});
+
+  const environment=String(process.env.VERCEL_ENV||process.env.NODE_ENV||'development').toLowerCase();
+  const isProduction=environment==='production';
+  const siteKey=isProduction?process.env.TURNSTILE_SITE_KEY:(process.env.TURNSTILE_SITE_KEY||TEST_SITE_KEY);
+
+  if(!siteKey){
+    return res.status(503).json({ok:false,message:'Sicherheitsprüfung ist derzeit nicht verfügbar.'});
+  }
+
+  return res.status(200).json({ok:true,siteKey});
+};

--- a/public/participation.js
+++ b/public/participation.js
@@ -54,20 +54,90 @@
     }));
   }
 
+  function waitForTurnstile(timeout=10000){
+    if(window.turnstile)return Promise.resolve(window.turnstile);
+    return new Promise((resolve,reject)=>{
+      const started=Date.now();
+      const timer=setInterval(()=>{
+        if(window.turnstile){
+          clearInterval(timer);
+          resolve(window.turnstile);
+        }else if(Date.now()-started>timeout){
+          clearInterval(timer);
+          reject(new Error('Sicherheitsprüfung konnte nicht geladen werden.'));
+        }
+      },100);
+    });
+  }
+
+  async function initializeTurnstile(){
+    const forms=all('form[data-submit-form]');
+    if(!forms.length)return;
+    try{
+      const configResponse=await fetch('/api/turnstile-config',{headers:{'Accept':'application/json'}});
+      const config=await configResponse.json();
+      if(!configResponse.ok||!config.siteKey)throw new Error(config.message||'Sicherheitsprüfung ist derzeit nicht verfügbar.');
+
+      if(!document.querySelector('script[data-turnstile-script]')){
+        const script=document.createElement('script');
+        script.src='https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+        script.async=true;
+        script.defer=true;
+        script.dataset.turnstileScript='';
+        document.head.appendChild(script);
+      }
+
+      const turnstile=await waitForTurnstile();
+      forms.forEach(form=>{
+        const button=form.querySelector('button[type=submit]');
+        if(!button||form.dataset.turnstileWidgetId)return;
+        const slot=document.createElement('div');
+        slot.className='turnstile-slot';
+        slot.setAttribute('aria-label','Sicherheitsprüfung gegen automatisierte Anfragen');
+        button.parentNode.insertBefore(slot,button);
+        const widgetId=turnstile.render(slot,{
+          sitekey:config.siteKey,
+          theme:'auto',
+          callback:token=>{ form.dataset.turnstileToken=token; },
+          'expired-callback':()=>{ form.dataset.turnstileToken=''; },
+          'error-callback':()=>{ form.dataset.turnstileToken=''; }
+        });
+        form.dataset.turnstileWidgetId=String(widgetId);
+      });
+    }catch(error){
+      forms.forEach(form=>{
+        const button=form.querySelector('button[type=submit]');
+        const target=form.querySelector('[data-preview-result]');
+        if(button)button.disabled=true;
+        if(target){
+          target.hidden=false;
+          target.textContent=error.message||'Sicherheitsprüfung ist derzeit nicht verfügbar.';
+        }
+      });
+    }
+  }
+
   function initializeForm(form){
     const startedField=form.elements.formStartedAt;
     if(startedField)startedField.value=Date.now();
 
     form.addEventListener('submit',async event=>{
       event.preventDefault();
+      const target=form.querySelector('[data-preview-result]');
+      const button=form.querySelector('button[type=submit]');
+
       if(!form.checkValidity()){
         form.reportValidity();
         form.querySelector(':invalid')?.focus();
         return;
       }
+      if(!form.dataset.turnstileToken){
+        target.hidden=false;
+        target.textContent='Bitte schließen Sie zuerst die Sicherheitsprüfung gegen automatisierte Anfragen ab.';
+        target.focus();
+        return;
+      }
 
-      const target=form.querySelector('[data-preview-result]');
-      const button=form.querySelector('button[type=submit]');
       button.disabled=true;
       target.hidden=false;
       target.textContent='Ihre Angaben werden übermittelt …';
@@ -84,6 +154,7 @@
       });
       data.privacy=form.elements.privacy.checked;
       data.formStartedAt=Number(data.formStartedAt);
+      data.turnstileToken=form.dataset.turnstileToken;
 
       try{
         const response=await fetch('/api/submit',{
@@ -95,9 +166,13 @@
         if(!response.ok)throw new Error(result.message||'Übermittlung fehlgeschlagen.');
         target.textContent=result.message;
         form.reset();
+        form.dataset.turnstileToken='';
         if(startedField)startedField.value=Date.now();
+        if(window.turnstile&&form.dataset.turnstileWidgetId)window.turnstile.reset(form.dataset.turnstileWidgetId);
         paint();
       }catch(error){
+        form.dataset.turnstileToken='';
+        if(window.turnstile&&form.dataset.turnstileWidgetId)window.turnstile.reset(form.dataset.turnstileWidgetId);
         target.textContent=error.message||'Die Übermittlung ist fehlgeschlagen. Bitte versuchen Sie es später erneut.';
       }finally{
         button.disabled=false;
@@ -108,6 +183,7 @@
   renderEventCards();
   bindEventSelection();
   all('form[data-submit-form]').forEach(initializeForm);
+  initializeTurnstile();
   paint();
 
   const section=params.get('section')||location.hash.slice(1);


### PR DESCRIPTION
Security-Hardening für die öffentlichen ZukunftsCheck-Formulare.

Enthalten:
- Cloudflare Turnstile im Client für alle drei Datenwege,
- zwingende serverseitige Siteverify-Prüfung vor Mailversand,
- Produktion fail-closed: ohne echte TURNSTILE_SITE_KEY / TURNSTILE_SECRET_KEY keine ungeschützte Übermittlung,
- offizielle Cloudflare-Testschlüssel ausschließlich außerhalb Production,
- Vercel-Origin-Prüfung auf eigene ZukunftsCheck-Deployments eingegrenzt,
- bestehender Honeypot, Zeitprüfung und Validierung bleiben erhalten,
- zusätzliches lokales 24h-Limit neben 5/10-Minuten-Limit.

Wichtig: Vor Merge nach main müssen echte Turnstile-Schlüssel für zukunftscheck.org in der Production-Umgebung gesetzt werden. Der Branch/Preview ist mit offiziellen Testschlüsseln prüfbar.