### PR TITLE
CSP für Cloudflare Turnstile freigeben

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'"
+          "value": "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self' https://challenges.cloudflare.com; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com"
         },
         {
           "key": "Permissions-Policy",


### PR DESCRIPTION
Hotfix nach PR #39: Die bestehende Content-Security-Policy blockiert externe Turnstile-Skripte/Frames/Verbindungen. Dieser PR erlaubt ausschließlich https://challenges.cloudflare.com für script-src, connect-src und frame-src; alle übrigen CSP-Grenzen bleiben unverändert.