### PR TITLE
Desktop: Beteiligungs-Hero-Titel einzeilig darstellen

### DIFF
--- a/public/styles/brand.css
+++ b/public/styles/brand.css
@@ -514,3 +514,11 @@ body:has(.module-page form[data-submit-form]) .module-page .section {
     border-radius: 18px !important;
   }
 }
+
+/* Beteiligungsseite: Desktop-Titel bewusst einzeilig, kleinere Viewports bleiben unverändert. */
+@media (min-width: 1200px) {
+  body:has(.module-page form[data-submit-form]) .module-hero h1 {
+    max-width: none;
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
Passt die Beteiligungsseite ausschließlich für große Desktop-Viewports an. Ab 1200 px wird der Hero-Titel nicht mehr durch die bisherige max-width begrenzt und bleibt einzeilig. Tablet-, Laptop- und Mobile-Regeln bleiben unverändert.