### PR TITLE
T2a: Präsentationslogik aus mobile-navigation.js auslagern

### DIFF
--- a/public/scripts/mobile-navigation.js
+++ b/public/scripts/mobile-navigation.js
@@ -1,78 +1,15 @@
 (() => {
+  if (!document.querySelector('script[data-zs-site-presentation]')) {
+    const presentationScript = document.createElement('script');
+    presentationScript.src = '/scripts/site-presentation.js';
+    presentationScript.dataset.zsSitePresentation = '';
+    document.head.appendChild(presentationScript);
+  }
+
   const header = document.querySelector('.site-header');
   const nav = header?.querySelector('nav');
 
   if (!header || !nav) return;
-
-  document.querySelectorAll('.hero, .module-hero').forEach(hero => {
-    if (!hero.querySelector(':scope > .hero-watermark')) {
-      const watermark = document.createElement('span');
-      watermark.className = 'hero-watermark';
-      watermark.setAttribute('aria-hidden', 'true');
-      hero.appendChild(watermark);
-    }
-
-    if (!hero.querySelector(':scope > .hero-watermark-top')) {
-      const watermarkTop = document.createElement('span');
-      watermarkTop.className = 'hero-watermark-top';
-      watermarkTop.setAttribute('aria-hidden', 'true');
-      hero.appendChild(watermarkTop);
-    }
-
-    if (!hero.querySelector(':scope > .hero-watermark-center')) {
-      const watermarkCenter = document.createElement('span');
-      watermarkCenter.className = 'hero-watermark-center';
-      watermarkCenter.setAttribute('aria-hidden', 'true');
-      hero.appendChild(watermarkCenter);
-    }
-  });
-
-  const homepageHeroCard = document.querySelector('.hero[aria-labelledby="hero-title"] .hero-card');
-  if (homepageHeroCard) {
-    homepageHeroCard.querySelector('.text-link')?.remove();
-
-    if (homepageHeroCard.tagName !== 'A') {
-      const heroLink = document.createElement('a');
-      heroLink.href = '/teilnahme.html#stufe-0';
-      heroLink.className = homepageHeroCard.className;
-      heroLink.setAttribute('aria-label', 'Stufe 0 ansehen');
-      heroLink.style.marginBottom = '0';
-      heroLink.style.textDecoration = 'none';
-
-      while (homepageHeroCard.firstChild) {
-        heroLink.appendChild(homepageHeroCard.firstChild);
-      }
-
-      homepageHeroCard.replaceWith(heroLink);
-    }
-  }
-
-  const definitionTitle = document.querySelector('#definition-title');
-  if (definitionTitle && !definitionTitle.querySelector('.desktop-definition-break')) {
-    definitionTitle.replaceChildren(
-      document.createTextNode('Orientierung, Strukturierung und Klärung'),
-      Object.assign(document.createElement('br'), { className: 'desktop-definition-break' }),
-      document.createTextNode('des nächsten belastbaren Schritts.')
-    );
-  }
-
-  const stagesTitle = document.querySelector('#stages-title');
-  if (stagesTitle && !stagesTitle.querySelector('.desktop-stages-break')) {
-    stagesTitle.replaceChildren(
-      document.createTextNode('Von der kostenfreien ersten Einordnung'),
-      Object.assign(document.createElement('br'), { className: 'desktop-stages-break' }),
-      document.createTextNode('zum passenden nächsten Schritt.')
-    );
-  }
-
-  const limitsTitle = document.querySelector('#limits-title');
-  if (limitsTitle && !limitsTitle.querySelector('.desktop-limits-break')) {
-    limitsTitle.replaceChildren(
-      document.createTextNode('Der ZukunftsCheck bleibt vor Fachplanung,'),
-      Object.assign(document.createElement('br'), { className: 'desktop-limits-break' }),
-      document.createTextNode('Umsetzung und spezialisierten Beratungsleistungen.')
-    );
-  }
 
   /* Globale Navigation: auf allen Inhaltsseiten dieselben fünf Hauptziele. */
   const currentPath = window.location.pathname;
@@ -129,17 +66,4 @@
   window.addEventListener('resize', () => {
     if (window.innerWidth > 760) closeMenu();
   });
-
-  const applicationGrid = document.querySelector('#angebote .cards.three');
-  if (applicationGrid && applicationGrid.children.length === 6) {
-    if (!document.querySelector('link[href="/styles/anwendungsfelder.css"]')) {
-      const stylesheet = document.createElement('link');
-      stylesheet.rel = 'stylesheet';
-      stylesheet.href = '/styles/anwendungsfelder.css';
-      document.head.appendChild(stylesheet);
-    }
-
-    applicationGrid.classList.add('applications-grid');
-    applicationGrid.children[5].classList.add('project-control-card');
-  }
 })();

--- a/public/scripts/mobile-navigation.js
+++ b/public/scripts/mobile-navigation.js
@@ -2,6 +2,7 @@
   if (!document.querySelector('script[data-zs-site-presentation]')) {
     const presentationScript = document.createElement('script');
     presentationScript.src = '/scripts/site-presentation.js';
+    presentationScript.async = false;
     presentationScript.dataset.zsSitePresentation = '';
     document.head.appendChild(presentationScript);
   }

--- a/public/scripts/site-presentation.js
+++ b/public/scripts/site-presentation.js
@@ -1,0 +1,84 @@
+(() => {
+  document.querySelectorAll('.hero, .module-hero').forEach(hero => {
+    if (!hero.querySelector(':scope > .hero-watermark')) {
+      const watermark = document.createElement('span');
+      watermark.className = 'hero-watermark';
+      watermark.setAttribute('aria-hidden', 'true');
+      hero.appendChild(watermark);
+    }
+
+    if (!hero.querySelector(':scope > .hero-watermark-top')) {
+      const watermarkTop = document.createElement('span');
+      watermarkTop.className = 'hero-watermark-top';
+      watermarkTop.setAttribute('aria-hidden', 'true');
+      hero.appendChild(watermarkTop);
+    }
+
+    if (!hero.querySelector(':scope > .hero-watermark-center')) {
+      const watermarkCenter = document.createElement('span');
+      watermarkCenter.className = 'hero-watermark-center';
+      watermarkCenter.setAttribute('aria-hidden', 'true');
+      hero.appendChild(watermarkCenter);
+    }
+  });
+
+  const homepageHeroCard = document.querySelector('.hero[aria-labelledby="hero-title"] .hero-card');
+  if (homepageHeroCard) {
+    homepageHeroCard.querySelector('.text-link')?.remove();
+
+    if (homepageHeroCard.tagName !== 'A') {
+      const heroLink = document.createElement('a');
+      heroLink.href = '/teilnahme.html#stufe-0';
+      heroLink.className = homepageHeroCard.className;
+      heroLink.setAttribute('aria-label', 'Stufe 0 ansehen');
+      heroLink.style.marginBottom = '0';
+      heroLink.style.textDecoration = 'none';
+
+      while (homepageHeroCard.firstChild) {
+        heroLink.appendChild(homepageHeroCard.firstChild);
+      }
+
+      homepageHeroCard.replaceWith(heroLink);
+    }
+  }
+
+  const definitionTitle = document.querySelector('#definition-title');
+  if (definitionTitle && !definitionTitle.querySelector('.desktop-definition-break')) {
+    definitionTitle.replaceChildren(
+      document.createTextNode('Orientierung, Strukturierung und Klärung'),
+      Object.assign(document.createElement('br'), { className: 'desktop-definition-break' }),
+      document.createTextNode('des nächsten belastbaren Schritts.')
+    );
+  }
+
+  const stagesTitle = document.querySelector('#stages-title');
+  if (stagesTitle && !stagesTitle.querySelector('.desktop-stages-break')) {
+    stagesTitle.replaceChildren(
+      document.createTextNode('Von der kostenfreien ersten Einordnung'),
+      Object.assign(document.createElement('br'), { className: 'desktop-stages-break' }),
+      document.createTextNode('zum passenden nächsten Schritt.')
+    );
+  }
+
+  const limitsTitle = document.querySelector('#limits-title');
+  if (limitsTitle && !limitsTitle.querySelector('.desktop-limits-break')) {
+    limitsTitle.replaceChildren(
+      document.createTextNode('Der ZukunftsCheck bleibt vor Fachplanung,'),
+      Object.assign(document.createElement('br'), { className: 'desktop-limits-break' }),
+      document.createTextNode('Umsetzung und spezialisierten Beratungsleistungen.')
+    );
+  }
+
+  const applicationGrid = document.querySelector('#angebote .cards.three');
+  if (applicationGrid && applicationGrid.children.length === 6) {
+    if (!document.querySelector('link[href="/styles/anwendungsfelder.css"]')) {
+      const stylesheet = document.createElement('link');
+      stylesheet.rel = 'stylesheet';
+      stylesheet.href = '/styles/anwendungsfelder.css';
+      document.head.appendChild(stylesheet);
+    }
+
+    applicationGrid.classList.add('applications-grid');
+    applicationGrid.children[5].classList.add('project-control-card');
+  }
+})();

--- a/tests/ui-consistency-check.mjs
+++ b/tests/ui-consistency-check.mjs
@@ -15,6 +15,7 @@ const pages=[
 for(const page of pages)assert.ok(fs.existsSync(path.join(root,page)),`${page} fehlt`);
 
 const nav=read('scripts/mobile-navigation.js');
+const presentation=read('scripts/site-presentation.js');
 const brandManifest=read('styles/brand.css');
 const consistency=read('styles/ui-consistency.css');
 const colorBalance=read('styles/ui-color-balance.css');
@@ -25,6 +26,12 @@ for(const label of ['Start','Anwendungsfelder','Projektsteuerung','Beteiligung',
   assert.ok(nav.includes(`label: '${label}'`),`Globale Navigation fehlt: ${label}`);
 }
 assert.match(nav,/nav\.replaceChildren/,'Navigation wird nicht zentral normalisiert');
+assert.match(nav,/site-presentation\.js/,'T2a-Bootstrap für getrennte Präsentationslogik fehlt');
+
+for(const marker of ['hero-watermark','desktop-definition-break','desktop-stages-break','desktop-limits-break','anwendungsfelder.css','project-control-card']){
+  assert.ok(!nav.includes(marker),`Fachfremde Präsentationslogik verbleibt in mobile-navigation.js: ${marker}`);
+  assert.ok(presentation.includes(marker),`Ausgelagerte Präsentationslogik fehlt in site-presentation.js: ${marker}`);
+}
 
 const staticStyles=[
   '/styles/brand-base.css',
@@ -80,6 +87,7 @@ assert.equal((events.match(/class="badge event-badge"/g)||[]).length,2,'Die zwei
 for(const title of ['All-Electric-In: Deutschland wird Electric State','All-Electric-In: Die Praxis'])assert.ok(events.includes(title),`Veranstaltungstitel fehlt: ${title}`);
 
 assert.match(participation,/insertBefore\(article,completedCard\)/,'Kommende Veranstaltungen werden nicht vor der abgeschlossenen Hamm-Veranstaltung einsortiert');
+assert.match(participation,/mobile-navigation\.js/,'Beteiligungsseite lädt weiterhin den gemeinsamen Navigationspfad');
 
 for(const page of ['veranstaltung-walsrode.html','veranstaltung-altenwahlingen.html','veranstaltung-hamm.html']){
   const html=read(page);
@@ -88,4 +96,4 @@ for(const page of ['veranstaltung-walsrode.html','veranstaltung-altenwahlingen.h
   assert.match(html,/scripts\/mobile-navigation\.js/,`${page}: globale Navigation fehlt`);
 }
 
-console.log('ZS-WEB-UI: statische CSS-Ladung sowie Navigations-, Raster-, Karten- und Event-Konsistenzprüfung bestanden.');
+console.log('ZS-WEB-UI: T2a-Verantwortungstrennung, statische CSS-Ladung sowie Navigations-, Raster-, Karten- und Event-Konsistenzprüfung bestanden.');

--- a/tests/ui-consistency-check.mjs
+++ b/tests/ui-consistency-check.mjs
@@ -27,6 +27,7 @@ for(const label of ['Start','Anwendungsfelder','Projektsteuerung','Beteiligung',
 }
 assert.match(nav,/nav\.replaceChildren/,'Navigation wird nicht zentral normalisiert');
 assert.match(nav,/site-presentation\.js/,'T2a-Bootstrap für getrennte Präsentationslogik fehlt');
+assert.match(nav,/presentationScript\.async\s*=\s*false/,'T2a-Präsentationsscript muss deterministisch und nicht async geladen werden');
 
 for(const marker of ['hero-watermark','desktop-definition-break','desktop-stages-break','desktop-limits-break','anwendungsfelder.css','project-control-card']){
   assert.ok(!nav.includes(marker),`Fachfremde Präsentationslogik verbleibt in mobile-navigation.js: ${marker}`);
@@ -96,4 +97,4 @@ for(const page of ['veranstaltung-walsrode.html','veranstaltung-altenwahlingen.h
   assert.match(html,/scripts\/mobile-navigation\.js/,`${page}: globale Navigation fehlt`);
 }
 
-console.log('ZS-WEB-UI: T2a-Verantwortungstrennung, statische CSS-Ladung sowie Navigations-, Raster-, Karten- und Event-Konsistenzprüfung bestanden.');
+console.log('ZS-WEB-UI: T2a-Verantwortungstrennung, deterministischer Präsentations-Bootstrap, statische CSS-Ladung sowie Navigations-, Raster-, Karten- und Event-Konsistenzprüfung bestanden.');


### PR DESCRIPTION
Teil von #43 / konkret #48.

Diese T2a-Tranche trennt die fachfremde Präsentationslogik aus `public/scripts/mobile-navigation.js` heraus, ohne Design-, Text-, Formular-, Turnstile-, API- oder CSS-Kaskadenänderung.

Umgesetzt:
- neues Modul `public/scripts/site-presentation.js` für Hero-Wasserzeichen, Startseiten-Hero-Link-Umbau, feste Desktop-Überschriftenumbrüche und Anwendungsfelder-Aufbereitung inkl. bedingtem `anwendungsfelder.css`;
- `mobile-navigation.js` enthält nur noch Navigation/Menu plus einen bewusst vorläufigen Bootstrap-Aufruf für `site-presentation.js`;
- bestehender Sonderpfad `participation.js` bleibt unverändert und lädt weiterhin `mobile-navigation.js`, wodurch auch die Präsentationslogik erreichbar bleibt;
- Testsuite prüft explizit, dass die Präsentationsmarker nicht mehr im Navigationskern liegen und vollständig im neuen Modul vorhanden sind.

Wichtig: Dies ist bewusst T2a, noch nicht der vollständige T2-Abschluss. Der eine Bootstrap-Aufruf aus `mobile-navigation.js` wird erst nach Regressionstest/Preview bewertet. Kein Merge ohne visuellen Vergleich und unabhängigen Gegencheck.