### PR TITLE
T3c: Redundantes !important beim Eventposter-Schatten entfernen

### DIFF
--- a/public/styles/ui-consistency.css
+++ b/public/styles/ui-consistency.css
@@ -141,7 +141,7 @@
 }
 .event-detail>.lead{max-width:760px}
 .event-poster{max-width:560px!important;margin:34px auto 42px!important}
-.event-poster img{border-radius:var(--ui-radius)!important;box-shadow:none!important;border:1px solid rgba(18,59,86,.17)}
+.event-poster img{border-radius:var(--ui-radius)!important;box-shadow:none;border:1px solid rgba(18,59,86,.17)}
 .event-facts{
   grid-template-columns:repeat(3,minmax(0,1fr))!important;
   gap:12px!important;


### PR DESCRIPTION
Teil von #52, konkret #57.

Änderung ausschließlich in `public/styles/ui-consistency.css`:
- `box-shadow:none!important` bei `.event-poster img` wird zu `box-shadow:none`.
- `border-radius:var(--ui-radius)!important` bleibt unverändert.
- Keine weiteren CSS-, HTML-, JS-, Formular-, Turnstile- oder API-Änderungen.

Begründung: `main.css` setzt vorher auf demselben Selektor `.event-poster img` einen Schatten ohne `!important`; `ui-consistency.css` wird später geladen und gewinnt bei identischer Spezifität auch ohne `!important`. Keine spätere konkurrierende Regel vorhanden.

Gate vor Merge: CI + Vercel Preview + unabhängiger Computed-Style-/Pixel-Gegencheck.