### PR TITLE
T4c: Tote Startseiten-CTA-bottom-Deklarationen entfernen

### DIFF
--- a/public/styles/brand-base.css
+++ b/public/styles/brand-base.css
@@ -278,7 +278,6 @@ body:has(.module-page form[data-submit-form]) .module-page .section {
 .hero[aria-labelledby="hero-title"] .hero-card .text-link {
   position: absolute;
   left: 50%;
-  bottom: 8px;
   transform: translateX(-50%);
   z-index: 3;
   display: inline-flex !important;
@@ -319,7 +318,6 @@ body:has(.module-page form[data-submit-form]) .module-page .section {
 
 @media (max-width: 760px) {
   .hero[aria-labelledby="hero-title"] .hero-card .text-link {
-    bottom: 6px;
     min-height: 34px;
     padding: 7px 13px;
     font-size: .82rem;


### PR DESCRIPTION
Teil von #59, konkret #66.

Änderung ausschließlich in `public/styles/brand-base.css`.

Entfernt werden genau zwei historisch tote Deklarationen aus der alten Overlay-Phase des Startseiten-Hero-CTA:
- `bottom: 8px` in der älteren Basisregel;
- `bottom: 6px` in der älteren `@media (max-width:760px)`-Regel.

Beide Werte werden bereits später mit identischem Selektor/Spezifität durch die freigegebene Produktionsposition überschrieben:
- Basis: `bottom: -46px`;
- <=760px: `bottom: -43px`.

Keine weiteren CTA-, Hero-, Layout-, HTML-, JS-, Formular-, Turnstile- oder API-Änderungen.

Gate vor Merge: Diff-Scope, CI, Vercel Preview, Pixel-/Computed-Style-Gegencheck und unabhängige Freigabe.