### PR TITLE
T4e: Startseiten-Hero-Basisregel konsolidieren

### DIFF
--- a/public/styles/brand-base.css
+++ b/public/styles/brand-base.css
@@ -251,10 +251,16 @@ body:has(.module-page form[data-submit-form]) .module-page .section {
   display: block;
   width: min(100%, 500px);
   justify-self: end;
+  margin-top: -8px;
+  margin-bottom: 54px;
   padding: 0 !important;
   min-height: 0 !important;
   aspect-ratio: 1 / 1;
+  overflow: visible;
+  background: none !important;
   border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
   backdrop-filter: none !important;
 }
 
@@ -316,15 +322,6 @@ body:has(.module-page form[data-submit-form]) .module-page .section {
 /* Produktionsfreigabe Startseiten-Hero 2026-08-12. */
 
 /* Startseiten-Hero: CTA unterhalb der Bildbox statt als Overlay. */
-.hero[aria-labelledby="hero-title"] .hero-card {
-  margin-top: -8px;
-  margin-bottom: 54px;
-  overflow: visible;
-  background: none !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-}
-
 .hero[aria-labelledby="hero-title"] .hero-card::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
Teil von #59, konkret #71.

Änderung ausschließlich in `public/styles/brand-base.css`.

Für `.hero[aria-labelledby="hero-title"] .hero-card` wurden die sechs bereits wirksamen Produktionsdeklarationen aus dem späteren, identischen Basisblock in den ersten Basisblock verschoben:
- `margin-top: -8px`
- `margin-bottom: 54px`
- `overflow: visible`
- `background: none !important`
- `border-radius: 0 !important`
- `box-shadow: none !important`

Der danach leere doppelte Basisblock wurde entfernt.

Keine Zielwerte, Selektoren, Spezifitäten, Media-Query-Werte, Pseudo-Elemente, CTA-Regeln, No-JS-Fallbacks, HTML-, JS-, Formular-, Turnstile- oder API-Logik wurden verändert.

Gate vor Merge: Diff-Scope, CI, Vercel Preview, Pixel-/Computed-Style-Gegencheck und unabhängige Freigabe.