### PR TITLE
T4f: Redundante Responsive-radius-Resets im Startseiten-Hero entfernen

### DIFF
--- a/public/styles/brand-base.css
+++ b/public/styles/brand-base.css
@@ -341,7 +341,6 @@ body:has(.module-page form[data-submit-form]) .module-page .section {
   .hero[aria-labelledby="hero-title"] .hero-card {
     margin-top: 0;
     margin-bottom: 52px;
-    border-radius: 0 !important;
   }
 
   .hero[aria-labelledby="hero-title"] .hero-card::before {
@@ -353,7 +352,6 @@ body:has(.module-page form[data-submit-form]) .module-page .section {
   .hero[aria-labelledby="hero-title"] .hero-card {
     margin-top: 0;
     margin-bottom: 50px;
-    border-radius: 0 !important;
   }
 
   .hero[aria-labelledby="hero-title"] .hero-card::before {


### PR DESCRIPTION
Teil von #59, konkret #74.

Änderung ausschließlich in `public/styles/brand-base.css`.

Entfernt werden exakt zwei redundante Deklarationen `border-radius: 0 !important;` aus den Responsive-Blöcken für `.hero[aria-labelledby="hero-title"] .hero-card` bei `max-width:1000px` und `max-width:640px`.

Die führende Basisregel setzt `border-radius: 0 !important;` bereits dauerhaft. Die sichtbaren Bildradien 22/20/18px liegen separat auf `.hero-card::before` und bleiben unverändert.

Keine weiteren CSS-, HTML-, JS-, Formular-, Turnstile- oder API-Änderungen.

Gate vor Merge: Diff-Scope, CI, Vercel Preview, Computed-Style-/Pixelvergleich und unabhängige Freigabe.