### PR TITLE
Issue #77: Dezentes Seiten-Logo-Wasserzeichen – Preview (verworfen)

### DIFF
--- a/public/styles/brand.css
+++ b/public/styles/brand.css
@@ -8,3 +8,4 @@
 @import url('/styles/ui-consistency.css');
 @import url('/styles/ui-color-balance.css');
 @import url('/styles/home-workflow-cards.css');
+@import url('/styles/page-logo-watermark-preview.css');

--- a/public/styles/page-logo-watermark-preview.css
+++ b/public/styles/page-logo-watermark-preview.css
@@ -1,0 +1,39 @@
+/* Issue #77 – Musterstufe: sehr dezentes rundes ZukunftsCheck-Logo als Seiten-Wasserzeichen.
+   Bewusst nur auf drei repräsentativen Seiten aktiv. Kein Vollrollout. */
+
+:where(
+  body:has(.hero[aria-labelledby="hero-title"]),
+  body:has(.module-page form[data-submit-form]),
+  body:has(a[aria-current="page"][href="/kommune.html"])
+) {
+  background-image:
+    linear-gradient(rgba(244, 247, 249, .955), rgba(244, 247, 249, .955)),
+    url('/assets/ZC_Logo_rund.png');
+  background-repeat: repeat, no-repeat;
+  background-size: auto, clamp(420px, 46vw, 760px);
+  background-position: 0 0, calc(100% - 4vw) 56%;
+  background-attachment: scroll, fixed;
+}
+
+@media (max-width: 1000px) {
+  :where(
+    body:has(.hero[aria-labelledby="hero-title"]),
+    body:has(.module-page form[data-submit-form]),
+    body:has(a[aria-current="page"][href="/kommune.html"])
+  ) {
+    background-size: auto, min(68vw, 620px);
+    background-position: 0 0, calc(100% + 7vw) 54%;
+  }
+}
+
+@media (max-width: 760px) {
+  :where(
+    body:has(.hero[aria-labelledby="hero-title"]),
+    body:has(.module-page form[data-submit-form]),
+    body:has(a[aria-current="page"][href="/kommune.html"])
+  ) {
+    background-size: auto, min(92vw, 500px);
+    background-position: 0 0, 122% 52%;
+    background-attachment: scroll, scroll;
+  }
+}

--- a/public/styles/page-logo-watermark-preview.css
+++ b/public/styles/page-logo-watermark-preview.css
@@ -1,4 +1,4 @@
-/* Issue #77 – Musterstufe: sehr dezentes rundes ZukunftsCheck-Logo als Seiten-Wasserzeichen.
+/* Issue #77 – Musterstufe: dezentes rundes ZukunftsCheck-Logo als Seiten-Wasserzeichen.
    Bewusst nur auf drei repräsentativen Seiten aktiv. Kein Vollrollout. */
 
 :where(
@@ -7,7 +7,7 @@
   body:has(a[aria-current="page"][href="/kommune.html"])
 ) {
   background-image:
-    linear-gradient(rgba(244, 247, 249, .955), rgba(244, 247, 249, .955)),
+    linear-gradient(rgba(244, 247, 249, .90), rgba(244, 247, 249, .90)),
     url('/assets/ZC_Logo_rund.png');
   background-repeat: repeat, no-repeat;
   background-size: auto, clamp(420px, 46vw, 760px);


### PR DESCRIPTION
Musterstufe zu #77 auf Basis des T4-Design-Freeze `f07989c9c701f2f3be8aed96715ff9cc5a4d3bc7`.

Änderungen:
- neue zentrale `public/styles/page-logo-watermark-preview.css`;
- zusätzlicher Import in `public/styles/brand.css`;
- keine HTML-, JS-, Formular-, Turnstile- oder API-Änderung.

Preview bewusst nur auf drei repräsentativen Seiten/Seitentypen aktiv:
- Startseite (`index.html`)
- Teilnahme (`teilnahme.html`)
- Kommune (`kommune.html`)

Gestaltung:
- `ZC_Logo_rund.png` als sehr großes, stark abgeschwächtes Seiten-Wasserzeichen;
- visuelle Restintensität ca. 4,5 % über Canvas-Overlay;
- Desktop/Tablet/Mobil eigene Größe/Position;
- reine Background-Lösung, keine zusätzlichen DOM-Knoten, kein `z-index`, keine Pointer-Interaktion und keine neue Scroll-Geometrie.

Noch kein Vollrollout und ausdrücklich kein Merge vor visueller Freigabe und unabhängigem Gegencheck.