### PR TITLE
Startseite: Rechtsentwicklungs-Link weiß + Titelumbrüche

### DIFF
--- a/public/scripts/site-presentation.js
+++ b/public/scripts/site-presentation.js
@@ -78,6 +78,17 @@
     );
   }
 
+  const rechtsentwicklungTitle = document.querySelector('#rechtsentwicklung-title');
+  if (rechtsentwicklungTitle && !rechtsentwicklungTitle.querySelector('.desktop-rechtsentwicklung-break')) {
+    rechtsentwicklungTitle.replaceChildren(
+      document.createTextNode('Was geschieht, wenn bestehende Regeln,'),
+      Object.assign(document.createElement('br'), { className: 'desktop-rechtsentwicklung-break' }),
+      document.createTextNode('Zuständigkeiten oder Verfahren'),
+      Object.assign(document.createElement('br'), { className: 'desktop-rechtsentwicklung-break' }),
+      document.createTextNode('erkennbare Probleme nicht lösen?')
+    );
+  }
+
   const applicationGrid = document.querySelector('#angebote .cards.three');
   if (applicationGrid && applicationGrid.children.length === 6) {
     if (!document.querySelector('link[href="/styles/anwendungsfelder.css"]')) {

--- a/public/scripts/site-presentation.js
+++ b/public/scripts/site-presentation.js
@@ -78,6 +78,15 @@
     );
   }
 
+  const offersTitle = document.querySelector('#offers-title');
+  if (offersTitle && !offersTitle.querySelector('.mobile-offers-break')) {
+    offersTitle.replaceChildren(
+      document.createTextNode('Fünf Anwendungsfelder'),
+      Object.assign(document.createElement('br'), { className: 'mobile-offers-break' }),
+      document.createTextNode(' für unterschiedliche Entscheidungssituationen.')
+    );
+  }
+
   const rechtsentwicklungTitle = document.querySelector('#rechtsentwicklung-title');
   if (rechtsentwicklungTitle && !rechtsentwicklungTitle.querySelector('.desktop-rechtsentwicklung-break')) {
     rechtsentwicklungTitle.replaceChildren(

--- a/public/scripts/site-presentation.js
+++ b/public/scripts/site-presentation.js
@@ -47,7 +47,7 @@
     definitionTitle.replaceChildren(
       document.createTextNode('Orientierung, Strukturierung und Klärung'),
       Object.assign(document.createElement('br'), { className: 'desktop-definition-break' }),
-      document.createTextNode('des nächsten belastbaren Schritts.')
+      document.createTextNode(' des nächsten belastbaren Schritts.')
     );
   }
 
@@ -56,7 +56,7 @@
     stagesTitle.replaceChildren(
       document.createTextNode('Von der kostenfreien ersten Einordnung'),
       Object.assign(document.createElement('br'), { className: 'desktop-stages-break' }),
-      document.createTextNode('zum passenden nächsten Schritt.')
+      document.createTextNode(' zum passenden nächsten Schritt.')
     );
   }
 
@@ -65,7 +65,7 @@
     limitsTitle.replaceChildren(
       document.createTextNode('Der ZukunftsCheck bleibt vor Fachplanung,'),
       Object.assign(document.createElement('br'), { className: 'desktop-limits-break' }),
-      document.createTextNode('Umsetzung und spezialisierten Beratungsleistungen.')
+      document.createTextNode(' Umsetzung und spezialisierten Beratungsleistungen.')
     );
   }
 
@@ -74,7 +74,7 @@
     questionsTitle.replaceChildren(
       document.createTextNode('Am Anfang stehen Ziel, Rolle,'),
       Object.assign(document.createElement('br'), { className: 'desktop-questions-break' }),
-      document.createTextNode('Zuständigkeit und Entscheidungsbedarf.')
+      document.createTextNode(' Zuständigkeit und Entscheidungsbedarf.')
     );
   }
 
@@ -83,9 +83,9 @@
     rechtsentwicklungTitle.replaceChildren(
       document.createTextNode('Was geschieht, wenn bestehende Regeln,'),
       Object.assign(document.createElement('br'), { className: 'desktop-rechtsentwicklung-break' }),
-      document.createTextNode('Zuständigkeiten oder Verfahren'),
+      document.createTextNode(' Zuständigkeiten oder Verfahren'),
       Object.assign(document.createElement('br'), { className: 'desktop-rechtsentwicklung-break' }),
-      document.createTextNode('erkennbare Probleme nicht lösen?')
+      document.createTextNode(' erkennbare Probleme nicht lösen?')
     );
   }
 

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -83,8 +83,9 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
   text-align:center!important;
 }
 
-/* Dunkler Rechtsentwicklungsblock: Link muss auf der Fläche klar lesbar bleiben. */
-section[aria-labelledby="rechtsentwicklung-title"] .text-link{
+/* Dunkle Startseiten-Hervorhebungen: Textlinks müssen auf der Fläche klar lesbar bleiben. */
+section[aria-labelledby="rechtsentwicklung-title"] .text-link,
+section[aria-labelledby="stages-title"] .text-link{
   color:#fff!important;
   text-decoration-color:rgba(255,255,255,.72)!important;
 }

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -83,9 +83,16 @@ body:has(.module-page form[data-submit-form]) .module-page .cards.three>.path-ca
   text-align:center!important;
 }
 
+/* Dunkler Rechtsentwicklungsblock: Link muss auf der Fläche klar lesbar bleiben. */
+section[aria-labelledby="rechtsentwicklung-title"] .text-link{
+  color:#fff!important;
+  text-decoration-color:rgba(255,255,255,.72)!important;
+}
+
 @media(max-width:760px){
   #angebote .applications-grid>.project-control-card{padding-top:4.4rem!important}
   #definition-title .desktop-definition-break,
   #stages-title .desktop-stages-break,
-  #limits-title .desktop-limits-break{display:none}
+  #limits-title .desktop-limits-break,
+  #rechtsentwicklung-title .desktop-rechtsentwicklung-break{display:none}
 }

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -96,4 +96,11 @@ section[aria-labelledby="stages-title"] .text-link{
   #stages-title .desktop-stages-break,
   #limits-title .desktop-limits-break,
   #rechtsentwicklung-title .desktop-rechtsentwicklung-break{display:none}
+
+  /* Mobile Titel sollen natürlich umbrechen, aber keine unschönen Worttrennungen erzeugen. */
+  #stages-title{
+    hyphens:none;
+    word-break:normal;
+    overflow-wrap:normal;
+  }
 }

--- a/public/styles/ui-color-balance.css
+++ b/public/styles/ui-color-balance.css
@@ -90,6 +90,8 @@ section[aria-labelledby="stages-title"] .text-link{
   text-decoration-color:rgba(255,255,255,.72)!important;
 }
 
+.mobile-offers-break{display:none}
+
 @media(max-width:760px){
   #angebote .applications-grid>.project-control-card{padding-top:4.4rem!important}
   #definition-title .desktop-definition-break,
@@ -97,8 +99,11 @@ section[aria-labelledby="stages-title"] .text-link{
   #limits-title .desktop-limits-break,
   #rechtsentwicklung-title .desktop-rechtsentwicklung-break{display:none}
 
+  .mobile-offers-break{display:block}
+
   /* Mobile Titel sollen natürlich umbrechen, aber keine unschönen Worttrennungen erzeugen. */
-  #stages-title{
+  #stages-title,
+  #offers-title{
     hyphens:none;
     word-break:normal;
     overflow-wrap:normal;


### PR DESCRIPTION
Gezielter UI-Fix für den Rechtsentwicklungsblock auf der Startseite.

Änderungen:
- Link „Zur Systemischen Rechtsentwicklung →“ in Weiß auf dunkler Fläche;
- Desktop-Titelumbrüche nach „Regeln,“ und nach „Verfahren“;
- auf Mobil werden die erzwungenen Desktop-Umbrüche wie bei den bestehenden Titel-Fixes wieder deaktiviert;
- keine weiteren Text-, Layout-, Formular-, API- oder Funktionsänderungen.